### PR TITLE
V12 audit (7/10): medium DoS preconditions & artifact validation

### DIFF
--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -14,3 +14,4 @@ finding	severity	class	commit	status	notes
 64626	Medium	untrusted-artifact-validation	b01081c26	fixed	Unchecked leaf index panics
 64630	Medium	runtime-dos-preconditions	a35babbe2	fixed	Unchecked leading-zero underflow
 64633	Medium	runtime-dos-preconditions	63d703182	fixed	Unchecked widths exhaust circuit builder
+64634	Medium	gadget-constraint-soundness	58641cce6	fixed	Zero-bit checks add no constraint

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -13,3 +13,4 @@ finding	severity	class	commit	status	notes
 64610	Medium	runtime-dos-preconditions	45617b473	fixed	Unbounded context metadata DoS
 64626	Medium	untrusted-artifact-validation	b01081c26	fixed	Unchecked leaf index panics
 64630	Medium	runtime-dos-preconditions	a35babbe2	fixed	Unchecked leading-zero underflow
+64633	Medium	runtime-dos-preconditions	63d703182	fixed	Unchecked widths exhaust circuit builder

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -12,3 +12,4 @@ finding	severity	class	commit	status	notes
 64608	Medium	untrusted-artifact-validation	0cf34d74f	fixed	Unbounded verifier-target deserialization
 64610	Medium	runtime-dos-preconditions	45617b473	fixed	Unbounded context metadata DoS
 64626	Medium	untrusted-artifact-validation	b01081c26	fixed	Unchecked leaf index panics
+64630	Medium	runtime-dos-preconditions	a35babbe2	fixed	Unchecked leading-zero underflow

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -11,3 +11,4 @@ finding	severity	class	commit	status	notes
 64606	Medium	runtime-dos-preconditions	06041ed09	fixed	Malformed config panics reductions
 64608	Medium	untrusted-artifact-validation	0cf34d74f	fixed	Unbounded verifier-target deserialization
 64610	Medium	runtime-dos-preconditions	45617b473	fixed	Unbounded context metadata DoS
+64626	Medium	untrusted-artifact-validation	b01081c26	fixed	Unchecked leaf index panics

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -9,3 +9,4 @@ finding	severity	class	commit	status	notes
 64604	Medium	gadget-constraint-soundness	775cb8e09	fixed	Unconstrained branch selector
 64605	Medium	runtime-dos-preconditions	51b68f13c	fixed	Malformed matrix panics
 64606	Medium	runtime-dos-preconditions	06041ed09	fixed	Malformed config panics reductions
+64608	Medium	untrusted-artifact-validation	0cf34d74f	fixed	Unbounded verifier-target deserialization

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -17,3 +17,4 @@ finding	severity	class	commit	status	notes
 64634	Medium	gadget-constraint-soundness	58641cce6	fixed	Zero-bit checks add no constraint
 64638	Medium	gadget-constraint-soundness	eee642d34	fixed	Out-of-range indices alias last element
 64641	Medium	runtime-dos-preconditions	db4bcebfd	fixed	Insufficient routed wires panic
+64656	Medium	untrusted-artifact-validation	5f2123e09	fixed	Forged lookup rows trigger panics

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -16,3 +16,4 @@ finding	severity	class	commit	status	notes
 64633	Medium	runtime-dos-preconditions	63d703182	fixed	Unchecked widths exhaust circuit builder
 64634	Medium	gadget-constraint-soundness	58641cce6	fixed	Zero-bit checks add no constraint
 64638	Medium	gadget-constraint-soundness	eee642d34	fixed	Out-of-range indices alias last element
+64641	Medium	runtime-dos-preconditions	db4bcebfd	fixed	Insufficient routed wires panic

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -18,3 +18,4 @@ finding	severity	class	commit	status	notes
 64638	Medium	gadget-constraint-soundness	eee642d34	fixed	Out-of-range indices alias last element
 64641	Medium	runtime-dos-preconditions	db4bcebfd	fixed	Insufficient routed wires panic
 64656	Medium	untrusted-artifact-validation	5f2123e09	fixed	Forged lookup rows trigger panics
+64663	Medium	runtime-dos-preconditions	bc93cacce	test-only-covered	Invalid widths trigger reduction panic; root fixed by 06041ed09

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -15,3 +15,4 @@ finding	severity	class	commit	status	notes
 64630	Medium	runtime-dos-preconditions	a35babbe2	fixed	Unchecked leading-zero underflow
 64633	Medium	runtime-dos-preconditions	63d703182	fixed	Unchecked widths exhaust circuit builder
 64634	Medium	gadget-constraint-soundness	58641cce6	fixed	Zero-bit checks add no constraint
+64638	Medium	gadget-constraint-soundness	eee642d34	fixed	Out-of-range indices alias last element

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -10,3 +10,4 @@ finding	severity	class	commit	status	notes
 64605	Medium	runtime-dos-preconditions	51b68f13c	fixed	Malformed matrix panics
 64606	Medium	runtime-dos-preconditions	06041ed09	fixed	Malformed config panics reductions
 64608	Medium	untrusted-artifact-validation	0cf34d74f	fixed	Unbounded verifier-target deserialization
+64610	Medium	runtime-dos-preconditions	45617b473	fixed	Unbounded context metadata DoS

--- a/core/src/circuit_config.rs
+++ b/core/src/circuit_config.rs
@@ -244,6 +244,10 @@ impl CircuitConfig {
             return Err("num_constants must not be 0 (causes infinite loop in circuit build)");
         }
 
+        if self.fri_config.proof_of_work_bits > 64 {
+            return Err("proof_of_work_bits must be at most 64");
+        }
+
         if let ZkMode::PolyFri(poly_fri) = &self.zk_config.mode {
             poly_fri.check_valid()?;
         }

--- a/core/src/circuit_config.rs
+++ b/core/src/circuit_config.rs
@@ -268,6 +268,25 @@ impl CircuitConfig {
         Ok(())
     }
 
+    pub fn check_extension_gate_widths<const D: usize>(&self) -> Result<(), &'static str> {
+        if D == 0 {
+            return Err("extension degree must not be 0");
+        }
+        let mul_wires = 3usize
+            .checked_mul(D)
+            .ok_or("multiplication extension gate wire budget overflow")?;
+        if self.num_routed_wires < mul_wires {
+            return Err("not enough routed wires for multiplication extension gate");
+        }
+        let arithmetic_wires = 4usize
+            .checked_mul(D)
+            .ok_or("arithmetic extension gate wire budget overflow")?;
+        if self.num_routed_wires < arithmetic_wires {
+            return Err("not enough routed wires for arithmetic extension gate");
+        }
+        Ok(())
+    }
+
     /// Validate that the circuit config has valid parameters. Panics on failure.
     ///
     /// Use this at circuit build time where invalid config is a programmer error.

--- a/core/src/fri.rs
+++ b/core/src/fri.rs
@@ -275,6 +275,24 @@ impl FriConfig {
         1.0 / ((1 << self.rate_bits) as f64)
     }
 
+    pub fn required_proof_of_work_leading_zeros<F: RichField>(&self) -> anyhow::Result<u32> {
+        let field_bits = F::order().bits();
+        ensure!(
+            field_bits <= u64::BITS as u64,
+            "proof-of-work field order exceeds 64 bits"
+        );
+        let field_padding = u64::BITS as u32 - field_bits as u32;
+        let required = self
+            .proof_of_work_bits
+            .checked_add(field_padding)
+            .ok_or_else(|| anyhow::anyhow!("proof-of-work leading-zero requirement overflowed"))?;
+        ensure!(
+            required <= u64::BITS,
+            "proof-of-work leading-zero requirement exceeds 64 bits"
+        );
+        Ok(required)
+    }
+
     pub fn fri_params(&self, degree_bits: usize, leaf_hiding: bool) -> FriParams {
         let reduction_arity_bits = self.reduction_strategy.reduction_arity_bits(
             degree_bits,

--- a/core/src/fri_verifier.rs
+++ b/core/src/fri_verifier.rs
@@ -60,9 +60,9 @@ pub fn fri_verify_proof_of_work<F: RichField + Extendable<D>, const D: usize>(
     fri_pow_response: F,
     config: &crate::fri::FriConfig,
 ) -> Result<()> {
+    let required_leading_zeros = config.required_proof_of_work_leading_zeros::<F>()?;
     ensure!(
-        fri_pow_response.to_canonical_u64().leading_zeros()
-            >= config.proof_of_work_bits + (64 - F::order().bits()) as u32,
+        fri_pow_response.to_canonical_u64().leading_zeros() >= required_leading_zeros,
         "Invalid proof of work witness."
     );
 

--- a/core/src/merkle_tree.rs
+++ b/core/src/merkle_tree.rs
@@ -180,22 +180,60 @@ pub fn merkle_tree_prove<F: RichField, H: Hasher<F>>(
     cap_height: usize,
     digests: &[H::Hash],
 ) -> Vec<H::Hash> {
-    let num_layers = log2_strict(leaves_len) - cap_height;
-    debug_assert_eq!(leaf_index >> (cap_height + num_layers), 0);
+    try_merkle_tree_prove::<F, H>(leaf_index, leaves_len, cap_height, digests)
+        .expect("Merkle leaf index and tree metadata must be valid")
+}
 
-    let digest_len = 2 * (leaves_len - (1 << cap_height));
-    assert_eq!(digest_len, digests.len());
+pub fn try_merkle_tree_prove<F: RichField, H: Hasher<F>>(
+    leaf_index: usize,
+    leaves_len: usize,
+    cap_height: usize,
+    digests: &[H::Hash],
+) -> Result<Vec<H::Hash>> {
+    ensure!(
+        leaves_len.is_power_of_two(),
+        "Merkle tree leaf count must be a power of two"
+    );
+    ensure!(leaf_index < leaves_len, "Merkle leaf index is out of range");
+    let cap_len = checked_merkle_cap_len(cap_height)?;
+    ensure!(
+        cap_len <= leaves_len,
+        "Merkle cap height exceeds leaf height"
+    );
+
+    let num_layers = log2_strict(leaves_len) - cap_height;
+    let digest_len = leaves_len
+        .checked_sub(cap_len)
+        .and_then(|n| n.checked_mul(2))
+        .ok_or_else(|| anyhow::anyhow!("Merkle digest length overflow"))?;
+    ensure!(
+        digest_len == digests.len(),
+        "Merkle digest length does not match leaf count and cap height"
+    );
 
     let digest_tree: &[H::Hash] = {
         let tree_index = leaf_index >> num_layers;
         let tree_len = digest_len >> cap_height;
-        &digests[tree_len * tree_index..tree_len * (tree_index + 1)]
+        let tree_start = tree_len
+            .checked_mul(tree_index)
+            .ok_or_else(|| anyhow::anyhow!("Merkle digest tree index overflow"))?;
+        let tree_end = tree_start
+            .checked_add(tree_len)
+            .ok_or_else(|| anyhow::anyhow!("Merkle digest tree range overflow"))?;
+        ensure!(
+            tree_end <= digests.len(),
+            "Merkle digest tree range is out of bounds"
+        );
+        &digests[tree_start..tree_end]
     };
 
     // Mask out high bits to get the index within the sub-tree.
-    let mut pair_index = leaf_index & ((1 << num_layers) - 1);
-    (0..num_layers)
-        .map(|i| {
+    let subtree_len = 1usize
+        .checked_shl(num_layers.try_into().unwrap_or(usize::BITS))
+        .ok_or_else(|| anyhow::anyhow!("Merkle subtree length overflow"))?;
+    let mut pair_index = leaf_index & (subtree_len - 1);
+    let siblings = (0..num_layers)
+        .map(|i| -> Result<H::Hash> {
             let parity = pair_index & 1;
             pair_index >>= 1;
 
@@ -205,14 +243,30 @@ pub fn merkle_tree_prove<F: RichField, H: Hasher<F>>(
             // `pair_index` is the index of the pair within layer `i`.
             // The index of that the pair within `digests` is
             // `pair_index * 2 ** (i + 1) + (2 ** i - 1)`.
-            let siblings_index = (pair_index << (i + 1)) + (1 << i) - 1;
+            let shifted_pair_index = pair_index
+                .checked_shl((i + 1).try_into().unwrap_or(usize::BITS))
+                .ok_or_else(|| anyhow::anyhow!("Merkle sibling index overflow"))?;
+            let layer_offset = 1usize
+                .checked_shl(i.try_into().unwrap_or(usize::BITS))
+                .and_then(|n| n.checked_sub(1))
+                .ok_or_else(|| anyhow::anyhow!("Merkle sibling layer offset overflow"))?;
+            let siblings_index = shifted_pair_index
+                .checked_add(layer_offset)
+                .ok_or_else(|| anyhow::anyhow!("Merkle sibling index overflow"))?;
             // We have an index for the _pair_, but we want the index of the _sibling_.
             // Double the pair index to get the index of the left sibling. Conditionally add `1`
             // if we are to retrieve the right sibling.
-            let sibling_index = 2 * siblings_index + (1 - parity);
-            digest_tree[sibling_index]
+            let sibling_index = siblings_index
+                .checked_mul(2)
+                .and_then(|n| n.checked_add(1 - parity))
+                .ok_or_else(|| anyhow::anyhow!("Merkle sibling index overflow"))?;
+            digest_tree
+                .get(sibling_index)
+                .copied()
+                .ok_or_else(|| anyhow::anyhow!("Merkle sibling index is out of bounds"))
         })
-        .collect()
+        .collect::<Result<Vec<_>>>()?;
+    Ok(siblings)
 }
 
 impl<F: RichField, H: Hasher<F>> MerkleTree<F, H> {
@@ -249,17 +303,43 @@ impl<F: RichField, H: Hasher<F>> MerkleTree<F, H> {
         }
     }
 
+    pub fn try_get(&self, i: usize) -> Result<&[F]> {
+        self.leaves
+            .get(i)
+            .map(Vec::as_slice)
+            .ok_or_else(|| anyhow::anyhow!("Merkle leaf index is out of range"))
+    }
+
+    /// Return a leaf by index.
+    ///
+    /// Panics if `i` is out of range. Use [`Self::try_get`] for untrusted indices.
     pub fn get(&self, i: usize) -> &[F] {
-        &self.leaves[i]
+        self.try_get(i).expect("Merkle leaf index must be in range")
     }
 
     /// Create a Merkle proof from a leaf index.
-    pub fn prove(&self, leaf_index: usize) -> MerkleProof<F, H> {
+    pub fn try_prove(&self, leaf_index: usize) -> Result<MerkleProof<F, H>> {
+        ensure!(
+            !self.cap.is_empty() && self.cap.len().is_power_of_two(),
+            "Merkle cap must be non-empty and power-of-two sized"
+        );
         let cap_height = log2_strict(self.cap.len());
-        let siblings =
-            merkle_tree_prove::<F, H>(leaf_index, self.leaves.len(), cap_height, &self.digests);
+        let siblings = try_merkle_tree_prove::<F, H>(
+            leaf_index,
+            self.leaves.len(),
+            cap_height,
+            &self.digests,
+        )?;
 
-        MerkleProof { siblings }
+        Ok(MerkleProof { siblings })
+    }
+
+    /// Create a Merkle proof from a leaf index.
+    ///
+    /// Panics if `leaf_index` is out of range. Use [`Self::try_prove`] for untrusted indices.
+    pub fn prove(&self, leaf_index: usize) -> MerkleProof<F, H> {
+        self.try_prove(leaf_index)
+            .expect("Merkle leaf index must be in range")
     }
 }
 

--- a/plonky2/src/batch_fri/oracle.rs
+++ b/plonky2/src/batch_fri/oracle.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "std"))]
-use alloc::{format, vec::Vec};
+use alloc::{format, vec, vec::Vec};
 
 use anyhow::{ensure, Result};
 use itertools::Itertools;

--- a/plonky2/src/batch_fri/prover.rs
+++ b/plonky2/src/batch_fri/prover.rs
@@ -109,7 +109,7 @@ pub fn batch_fri_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>,
         challenger,
         n,
         fri_params,
-    );
+    )?;
 
     Ok(FriProof {
         commit_phase_merkle_caps: trees.iter().map(|t| t.cap.clone()).collect(),
@@ -254,7 +254,7 @@ fn batch_fri_prover_query_rounds<
     challenger: &mut Challenger<F, C::Hasher>,
     n: usize,
     fri_params: &FriParams,
-) -> Vec<FriQueryRound<F, C::Hasher, D>> {
+) -> Result<Vec<FriQueryRound<F, C::Hasher, D>>> {
     challenger
         .get_n_challenges(fri_params.config.num_query_rounds)
         .into_par_iter()
@@ -279,25 +279,26 @@ fn batch_fri_prover_query_round<
     trees: &[MerkleTree<F, C::Hasher>],
     mut x_index: usize,
     fri_params: &FriParams,
-) -> FriQueryRound<F, C::Hasher, D> {
+) -> Result<FriQueryRound<F, C::Hasher, D>> {
     let mut query_steps = Vec::with_capacity(trees.len());
     let initial_proof = initial_merkle_trees
         .iter()
-        .map(|t| {
-            (
-                t.values(x_index)
+        .map(|t| -> Result<_> {
+            Ok((
+                t.try_values(x_index)?
                     .iter()
                     .flatten()
                     .cloned()
                     .collect::<Vec<_>>(),
-                t.open_batch(x_index),
-            )
+                t.try_open_batch(x_index)?,
+            ))
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>>>()?;
     for (i, tree) in trees.iter().enumerate() {
         let arity_bits = fri_params.reduction_arity_bits[i];
-        let evals = unflatten(tree.get(x_index >> arity_bits));
-        let merkle_proof = tree.prove(x_index >> arity_bits);
+        let reduced_index = x_index >> arity_bits;
+        let evals = unflatten(tree.try_get(reduced_index)?);
+        let merkle_proof = tree.try_prove(reduced_index)?;
 
         query_steps.push(FriQueryStep {
             evals,
@@ -306,12 +307,12 @@ fn batch_fri_prover_query_round<
 
         x_index >>= arity_bits;
     }
-    FriQueryRound {
+    Ok(FriQueryRound {
         initial_trees_proof: FriInitialTreeProof {
             evals_proofs: initial_proof,
         },
         steps: query_steps,
-    }
+    })
 }
 
 #[cfg(test)]

--- a/plonky2/src/batch_fri/verifier.rs
+++ b/plonky2/src/batch_fri/verifier.rs
@@ -10,12 +10,11 @@ use crate::fri::proof::{
     eval_final_polys_at_point, FriChallenges, FriInitialTreeProof, FriProof, FriQueryRound,
 };
 use crate::fri::structure::{FriBatchInfo, FriInstanceInfo, FriOpenings};
-use crate::fri::validate_batch_fri_auxiliary_shape;
 use crate::fri::verifier::{
     compute_evaluation, eval_opening_expression, fri_verify_proof_of_work,
     PrecomputedReducedOpenings,
 };
-use crate::fri::FriParams;
+use crate::fri::{validate_batch_fri_auxiliary_shape, FriParams};
 use crate::hash::hash_types::RichField;
 use crate::hash::merkle_proofs::{verify_batch_merkle_proof_to_cap, verify_merkle_proof_to_cap};
 use crate::hash::merkle_tree::MerkleCap;

--- a/plonky2/src/fri/mod.rs
+++ b/plonky2/src/fri/mod.rs
@@ -23,15 +23,14 @@ pub mod validate_shape;
 pub mod verifier;
 pub mod witness_util;
 
-pub use validate_shape::{
-    validate_batch_fri_auxiliary_shape, validate_batch_fri_proof_shape,
-    validate_fri_auxiliary_shape,
-};
-
 // Re-export FRI types from core
 pub use qp_plonky2_core::{
     FriBatchMaskingParams, FriChallenger, FriConfig, FriConfigObserve, FriFinalPolyLayout,
     FriParams, FriParamsObserve, FriReductionStrategy,
+};
+pub use validate_shape::{
+    validate_batch_fri_auxiliary_shape, validate_batch_fri_proof_shape,
+    validate_fri_auxiliary_shape,
 };
 
 /// Trait for observing FRI configuration in a RecursiveChallenger (circuit target version).

--- a/plonky2/src/fri/prover.rs
+++ b/plonky2/src/fri/prover.rs
@@ -376,7 +376,9 @@ pub(crate) fn fri_proof_of_work<
     challenger: &mut Challenger<F, C::Hasher>,
     config: &FriConfig,
 ) -> F {
-    let min_leading_zeros = config.proof_of_work_bits + (64 - F::order().bits()) as u32;
+    let min_leading_zeros = config
+        .required_proof_of_work_leading_zeros::<F>()
+        .expect("Invalid FRI proof-of-work bits");
 
     // The easiest implementation would be repeatedly clone our Challenger. With each clone, we'd
     // observe an incrementing PoW witness, then get the PoW response. If it contained sufficient

--- a/plonky2/src/fri/recursive_verifier.rs
+++ b/plonky2/src/fri/recursive_verifier.rs
@@ -103,10 +103,10 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         fri_pow_response: Target,
         config: &FriConfig,
     ) {
-        self.assert_leading_zeros(
-            fri_pow_response,
-            config.proof_of_work_bits + (64 - F::order().bits()) as u32,
-        );
+        let required_leading_zeros = config
+            .required_proof_of_work_leading_zeros::<F>()
+            .expect("Invalid FRI proof-of-work bits");
+        self.assert_leading_zeros(fri_pow_response, required_leading_zeros);
     }
 
     pub fn verify_fri_proof<C: GenericConfig<D, F = F>>(

--- a/plonky2/src/gadgets/random_access.rs
+++ b/plonky2/src/gadgets/random_access.rs
@@ -10,13 +10,31 @@ use crate::iop::ext_target::ExtensionTarget;
 use crate::iop::target::Target;
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::VerifierCircuitTarget;
-use crate::util::log2_strict;
+use crate::util::{log2_ceil, log2_strict};
 
 impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
+    fn constrain_random_access_index(&mut self, access_index: Target, original_len: usize) {
+        assert!(original_len > 0, "random_access requires a non-empty list");
+        if original_len == 1 {
+            self.assert_zero(access_index);
+            return;
+        }
+
+        if original_len.is_power_of_two() {
+            return;
+        }
+
+        let bits = log2_ceil(original_len);
+        let max_valid_index = self.constant(F::from_canonical_usize(original_len - 1));
+        let remaining = self.sub(max_valid_index, access_index);
+        self.range_check(remaining, bits);
+    }
+
     /// Checks that a `Target` matches a vector at a particular index.
     pub fn random_access(&mut self, access_index: Target, v: Vec<Target>) -> Target {
         let mut v = v;
         let current_len = v.len();
+        self.constrain_random_access_index(access_index, current_len);
         let next_power_of_two = current_len.next_power_of_two();
         if current_len < next_power_of_two {
             // Get the last element (if there is one) and extend with it
@@ -56,15 +74,6 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         access_index: Target,
         v: Vec<ExtensionTarget<D>>,
     ) -> ExtensionTarget<D> {
-        let mut v = v;
-        let current_len = v.len();
-        let next_power_of_two = current_len.next_power_of_two();
-        if current_len < next_power_of_two {
-            // Get the last element (if there is one) and extend with it
-            if let Some(&last) = v.last() {
-                v.extend(repeat_n(last, next_power_of_two - current_len));
-            }
-        }
         let selected: Vec<_> = (0..D)
             .map(|i| self.random_access(access_index, v.iter().map(|et| et.0[i]).collect()))
             .collect();

--- a/plonky2/src/gadgets/range_check.rs
+++ b/plonky2/src/gadgets/range_check.rs
@@ -31,13 +31,21 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 
     /// Returns `(a,b)` such that `x = a + 2^n_log * b` with `a < 2^n_log`.
     /// `x` is assumed to be range-checked for having `num_bits` bits.
-    pub fn split_low_high(&mut self, x: Target, n_log: usize, num_bits: usize) -> (Target, Target) {
-        assert!(n_log <= num_bits, "n_log must not exceed num_bits");
-        assert!(n_log < u64::BITS as usize, "n_log must be less than 64");
-        assert!(
+    pub fn try_split_low_high(
+        &mut self,
+        x: Target,
+        n_log: usize,
+        num_bits: usize,
+    ) -> Result<(Target, Target)> {
+        ensure!(n_log <= num_bits, "n_log must not exceed num_bits");
+        ensure!(n_log < u64::BITS as usize, "n_log must be less than 64");
+        ensure!(
             num_bits <= u64::BITS as usize,
             "num_bits must be at most 64"
         );
+        let high_bits = num_bits
+            .checked_sub(n_log)
+            .ok_or_else(|| anyhow::anyhow!("n_log must not exceed num_bits"))?;
 
         let low = self.add_virtual_target();
         let high = self.add_virtual_target();
@@ -50,7 +58,6 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         });
 
         self.range_check(low, n_log);
-        let high_bits = num_bits - n_log;
         self.range_check(high, high_bits);
 
         let pow2 = 1u64
@@ -60,7 +67,17 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let comp_x = self.mul_add(high, pow2, low);
         self.connect(x, comp_x);
 
-        (low, high)
+        Ok((low, high))
+    }
+
+    /// Returns `(a,b)` such that `x = a + 2^n_log * b` with `a < 2^n_log`.
+    /// `x` is assumed to be range-checked for having `num_bits` bits.
+    ///
+    /// Panics if the widths are unsupported. Use [`Self::try_split_low_high`] for untrusted
+    /// widths.
+    pub fn split_low_high(&mut self, x: Target, n_log: usize, num_bits: usize) -> (Target, Target) {
+        self.try_split_low_high(x, n_log, num_bits)
+            .expect("split_low_high widths must be valid")
     }
 
     pub fn assert_bool(&mut self, b: BoolTarget) {

--- a/plonky2/src/gadgets/split_base.rs
+++ b/plonky2/src/gadgets/split_base.rs
@@ -47,8 +47,22 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     }
 
     /// Asserts that `x`'s big-endian bit representation has at least `leading_zeros` leading zeros.
+    pub fn try_assert_leading_zeros(&mut self, x: Target, leading_zeros: u32) -> Result<()> {
+        ensure!(
+            leading_zeros <= u64::BITS,
+            "leading_zeros must be at most 64"
+        );
+        self.range_check(x, (u64::BITS - leading_zeros) as usize);
+        Ok(())
+    }
+
+    /// Asserts that `x`'s big-endian bit representation has at least `leading_zeros` leading zeros.
+    ///
+    /// Panics if `leading_zeros > 64`. Use [`Self::try_assert_leading_zeros`] for untrusted
+    /// widths.
     pub(crate) fn assert_leading_zeros(&mut self, x: Target, leading_zeros: u32) {
-        self.range_check(x, (64 - leading_zeros) as usize);
+        self.try_assert_leading_zeros(x, leading_zeros)
+            .expect("leading_zeros must be at most 64");
     }
 
     /// Takes an iterator of bits `(b_i)` and returns `sum b_i * 2^i`, i.e.,

--- a/plonky2/src/gadgets/split_join.rs
+++ b/plonky2/src/gadgets/split_join.rs
@@ -24,6 +24,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     /// with `k` such that `k * num_routed_wires >= num_bits`.
     pub fn split_le(&mut self, integer: Target, num_bits: usize) -> Vec<BoolTarget> {
         if num_bits == 0 {
+            self.assert_zero(integer);
             return Vec::new();
         }
         let gate_type = BaseSumGate::<2>::new_from_config::<F>(&self.config);

--- a/plonky2/src/gadgets/split_join.rs
+++ b/plonky2/src/gadgets/split_join.rs
@@ -5,7 +5,7 @@ use alloc::{
     vec::Vec,
 };
 
-use anyhow::Result;
+use anyhow::{ensure, Result};
 
 use crate::field::extension::Extendable;
 use crate::gates::base_sum::BaseSumGate;
@@ -91,8 +91,8 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Spl
             integer_value >>= 1;
         }
 
-        debug_assert_eq!(
-            integer_value, 0,
+        ensure!(
+            integer_value == 0,
             "Integer too large to fit in given number of bits"
         );
 
@@ -150,9 +150,8 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Wir
             out_buffer.set_target(sum, F::from_canonical_u64(truncated_value))?;
         }
 
-        debug_assert_eq!(
-            integer_value,
-            0,
+        ensure!(
+            integer_value == 0,
             "Integer too large to fit in {} many `BaseSumGate`s",
             self.gates.len()
         );

--- a/plonky2/src/gates/arithmetic_extension.rs
+++ b/plonky2/src/gates/arithmetic_extension.rs
@@ -30,10 +30,21 @@ pub struct ArithmeticExtensionGate<const D: usize> {
 }
 
 impl<const D: usize> ArithmeticExtensionGate<D> {
-    pub const fn new_from_config(config: &CircuitConfig) -> Self {
-        Self {
-            num_ops: Self::num_ops(config),
+    pub fn try_new_from_config(config: &CircuitConfig) -> core::result::Result<Self, &'static str> {
+        let num_ops = Self::num_ops(config);
+        if num_ops == 0 {
+            return Err("not enough routed wires for arithmetic extension gate");
         }
+        Ok(Self { num_ops })
+    }
+
+    pub const fn new_from_config(config: &CircuitConfig) -> Self {
+        let num_ops = Self::num_ops(config);
+        assert!(
+            num_ops > 0,
+            "not enough routed wires for arithmetic extension gate"
+        );
+        Self { num_ops }
     }
 
     /// Determine the maximum number of operations that can fit in one gate for the given config.

--- a/plonky2/src/gates/base_sum.rs
+++ b/plonky2/src/gates/base_sum.rs
@@ -2,7 +2,7 @@
 use alloc::{format, string::String, vec, vec::Vec};
 use core::ops::Range;
 
-use anyhow::Result;
+use anyhow::{ensure, Result};
 
 use crate::field::extension::Extendable;
 use crate::field::packed::PackedField;
@@ -195,9 +195,8 @@ impl<F: RichField + Extendable<D>, const B: usize, const D: usize> SimpleGenerat
         let sum_value = witness
             .get_target(Target::wire(self.row, BaseSumGate::<B>::WIRE_SUM))
             .to_canonical_u64();
-        debug_assert_eq!(
-            (0..self.num_limbs).fold(sum_value, |acc, _| acc / (B as u64)),
-            0,
+        ensure!(
+            (0..self.num_limbs).fold(sum_value, |acc, _| acc / (B as u64)) == 0,
             "Integer too large to fit in given number of limbs"
         );
 

--- a/plonky2/src/gates/lookup.rs
+++ b/plonky2/src/gates/lookup.rs
@@ -95,10 +95,18 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for LookupGate {
         let lut_index = src.read_usize()?;
         let mut lut_hash = [0u8; 32];
         src.read_exact(&mut lut_hash)?;
+        if num_slots != Self::num_slots(&common_data.config) {
+            return Err(crate::util::serialization::IoError);
+        }
+        let lut = common_data
+            .luts
+            .get(lut_index)
+            .ok_or(crate::util::serialization::IoError)?
+            .clone();
 
         Ok(Self {
             num_slots,
-            lut: common_data.luts[lut_index].clone(),
+            lut,
             lut_hash,
         })
     }

--- a/plonky2/src/gates/lookup_table.rs
+++ b/plonky2/src/gates/lookup_table.rs
@@ -110,10 +110,18 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for LookupTableGat
         let lut_index = src.read_usize()?;
         let mut lut_hash = [0u8; 32];
         src.read_exact(&mut lut_hash)?;
+        if num_slots != Self::num_slots(&common_data.config) {
+            return Err(crate::util::serialization::IoError);
+        }
+        let lut = common_data
+            .luts
+            .get(lut_index)
+            .ok_or(crate::util::serialization::IoError)?
+            .clone();
 
         Ok(Self {
             num_slots,
-            lut: common_data.luts[lut_index].clone(),
+            lut,
             lut_hash,
             last_lut_row,
         })

--- a/plonky2/src/gates/multiplication_extension.rs
+++ b/plonky2/src/gates/multiplication_extension.rs
@@ -30,10 +30,21 @@ pub struct MulExtensionGate<const D: usize> {
 }
 
 impl<const D: usize> MulExtensionGate<D> {
-    pub const fn new_from_config(config: &CircuitConfig) -> Self {
-        Self {
-            num_ops: Self::num_ops(config),
+    pub fn try_new_from_config(config: &CircuitConfig) -> core::result::Result<Self, &'static str> {
+        let num_ops = Self::num_ops(config);
+        if num_ops == 0 {
+            return Err("not enough routed wires for multiplication extension gate");
         }
+        Ok(Self { num_ops })
+    }
+
+    pub const fn new_from_config(config: &CircuitConfig) -> Self {
+        let num_ops = Self::num_ops(config);
+        assert!(
+            num_ops > 0,
+            "not enough routed wires for multiplication extension gate"
+        );
+        Self { num_ops }
     }
 
     /// Determine the maximum number of operations that can fit in one gate for the given config.

--- a/plonky2/src/gates/reducing.rs
+++ b/plonky2/src/gates/reducing.rs
@@ -8,6 +8,7 @@ use alloc::{
 use core::ops::Range;
 
 use anyhow::Result;
+use qp_plonky2_core::circuit_config::reducing_base_capacity;
 
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::gates::gate::Gate;
@@ -21,7 +22,6 @@ use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::{Buffer, IoResult, Read, Write};
-use qp_plonky2_core::circuit_config::reducing_base_capacity;
 
 /// Computes `sum alpha^i c_i` for a vector `c_i` of `num_coeffs` elements of the base field.
 #[derive(Debug, Default, Clone)]

--- a/plonky2/src/gates/reducing_extension.rs
+++ b/plonky2/src/gates/reducing_extension.rs
@@ -8,6 +8,7 @@ use alloc::{
 use core::ops::Range;
 
 use anyhow::Result;
+use qp_plonky2_core::circuit_config::reducing_extension_capacity;
 
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::gates::gate::Gate;
@@ -21,7 +22,6 @@ use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::{Buffer, IoResult, Read, Write};
-use qp_plonky2_core::circuit_config::reducing_extension_capacity;
 
 /// Computes `sum alpha^i c_i` for a vector `c_i` of `num_coeffs` elements of the extension field.
 #[derive(Debug, Clone, Default)]

--- a/plonky2/src/gates/selectors.rs
+++ b/plonky2/src/gates/selectors.rs
@@ -7,7 +7,6 @@
 use alloc::{vec, vec::Vec};
 
 use hashbrown::HashMap;
-
 // Re-export selector types from core
 pub use qp_plonky2_core::selectors::{LookupSelectors, SelectorsInfo, UNUSED_SELECTOR};
 

--- a/plonky2/src/hash/batch_merkle_tree.rs
+++ b/plonky2/src/hash/batch_merkle_tree.rs
@@ -3,12 +3,12 @@ use alloc::vec;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use itertools::Itertools;
+use anyhow::{ensure, Result};
 
 use crate::hash::hash_types::{RichField, NUM_HASH_OUT_ELTS};
 use crate::hash::merkle_proofs::MerkleProof;
 use crate::hash::merkle_tree::{
-    capacity_up_to_mut, fill_digests_buf, merkle_tree_prove, MerkleCap,
+    capacity_up_to_mut, checked_merkle_cap_len, fill_digests_buf, try_merkle_tree_prove, MerkleCap,
 };
 use crate::plonk::config::{GenericHashOut, Hasher};
 use crate::util::log2_strict;
@@ -53,7 +53,7 @@ impl<F: RichField, H: Hasher<F>> BatchMerkleTree<F, H> {
         let num_digests = 2 * (leaves_len - (1 << cap_height));
         let mut digests = Vec::with_capacity(num_digests);
         let digests_buf = capacity_up_to_mut(&mut digests, num_digests);
-        let mut digests_buf_pos = 0;
+        let mut digests_buf_pos: usize = 0;
 
         let mut cap = vec![];
         let dummy_leaves = vec![vec![F::ZERO]; 1 << cap_height];
@@ -129,38 +129,122 @@ impl<F: RichField, H: Hasher<F>> BatchMerkleTree<F, H> {
         }
     }
 
+    fn leaf_count(&self) -> Result<usize> {
+        ensure!(!self.leaves.is_empty(), "batch Merkle tree has no leaves");
+        let leaf_count = self.leaves[0].len();
+        ensure!(leaf_count > 0, "batch Merkle tree has no leaf rows");
+        ensure!(
+            leaf_count.is_power_of_two(),
+            "batch Merkle tree leaf count is not a power of two"
+        );
+        Ok(leaf_count)
+    }
+
     /// Create a Merkle proof from a leaf index.
-    pub fn open_batch(&self, leaf_index: usize) -> MerkleProof<F, H> {
-        let mut digests_buf_pos = 0;
-        let initial_leaf_height = log2_strict(self.leaves[0].len());
+    pub fn try_open_batch(&self, leaf_index: usize) -> Result<MerkleProof<F, H>> {
+        let leaf_count = self.leaf_count()?;
+        ensure!(
+            leaf_index < leaf_count,
+            "batch Merkle leaf index is out of range"
+        );
+        ensure!(
+            self.leaf_heights.len() == self.leaves.len(),
+            "batch Merkle leaf height metadata is malformed"
+        );
+        ensure!(
+            !self.cap.is_empty() && self.cap.len().is_power_of_two(),
+            "batch Merkle cap must be non-empty and power-of-two sized"
+        );
+
+        let mut digests_buf_pos: usize = 0;
+        let initial_leaf_height = log2_strict(leaf_count);
         let mut siblings = vec![];
         let mut cap_heights = self.leaf_heights.clone();
         cap_heights.push(log2_strict(self.cap.len()));
         for window in cap_heights.windows(2) {
             let cur_cap_height = window[0];
             let next_cap_height = window[1];
-            let num_digests: usize = 2 * ((1 << cur_cap_height) - (1 << next_cap_height));
-            siblings.extend::<Vec<_>>(merkle_tree_prove::<F, H>(
-                leaf_index >> (initial_leaf_height - cur_cap_height),
-                1 << cur_cap_height,
+            ensure!(
+                cur_cap_height <= initial_leaf_height,
+                "batch Merkle leaf height exceeds initial height"
+            );
+            ensure!(
+                next_cap_height <= cur_cap_height,
+                "batch Merkle cap heights are not descending"
+            );
+            let cur_cap_len = checked_merkle_cap_len(cur_cap_height)?;
+            let next_cap_len = checked_merkle_cap_len(next_cap_height)?;
+            let num_digests = cur_cap_len
+                .checked_sub(next_cap_len)
+                .and_then(|n| n.checked_mul(2))
+                .ok_or_else(|| anyhow::anyhow!("batch Merkle digest length overflow"))?;
+            let digests_end = digests_buf_pos
+                .checked_add(num_digests)
+                .ok_or_else(|| anyhow::anyhow!("batch Merkle digest range overflow"))?;
+            ensure!(
+                digests_end <= self.digests.len(),
+                "batch Merkle digest range is out of bounds"
+            );
+            let shift = initial_leaf_height - cur_cap_height;
+            siblings.extend::<Vec<_>>(try_merkle_tree_prove::<F, H>(
+                leaf_index >> shift,
+                cur_cap_len,
                 next_cap_height,
-                &self.digests[digests_buf_pos..digests_buf_pos + num_digests],
-            ));
+                &self.digests[digests_buf_pos..digests_end],
+            )?);
             digests_buf_pos += num_digests;
         }
+        ensure!(
+            digests_buf_pos == self.digests.len(),
+            "batch Merkle proof did not consume every digest"
+        );
 
-        MerkleProof { siblings }
+        Ok(MerkleProof { siblings })
     }
 
-    pub fn values(&self, leaf_index: usize) -> Vec<Vec<F>> {
-        let leaves_cap_height = log2_strict(self.leaves[0].len());
+    /// Create a Merkle proof from a leaf index.
+    ///
+    /// Panics if `leaf_index` is out of range. Use [`Self::try_open_batch`] for untrusted indices.
+    pub fn open_batch(&self, leaf_index: usize) -> MerkleProof<F, H> {
+        self.try_open_batch(leaf_index)
+            .expect("batch Merkle leaf index must be in range")
+    }
+
+    pub fn try_values(&self, leaf_index: usize) -> Result<Vec<Vec<F>>> {
+        let leaf_count = self.leaf_count()?;
+        ensure!(
+            leaf_index < leaf_count,
+            "batch Merkle leaf index is out of range"
+        );
+        ensure!(
+            self.leaf_heights.len() == self.leaves.len(),
+            "batch Merkle leaf height metadata is malformed"
+        );
+
+        let leaves_cap_height = log2_strict(leaf_count);
         self.leaves
             .iter()
             .zip(&self.leaf_heights)
-            .map(|(leaves, cap_height)| {
-                leaves[leaf_index >> (leaves_cap_height - cap_height)].clone()
+            .map(|(leaves, cap_height)| -> Result<Vec<F>> {
+                ensure!(
+                    *cap_height <= leaves_cap_height,
+                    "batch Merkle leaf height exceeds initial height"
+                );
+                let row = leaf_index >> (leaves_cap_height - cap_height);
+                leaves
+                    .get(row)
+                    .cloned()
+                    .ok_or_else(|| anyhow::anyhow!("batch Merkle leaf row is out of range"))
             })
-            .collect_vec()
+            .collect()
+    }
+
+    /// Return the batch-opened values at a leaf index.
+    ///
+    /// Panics if `leaf_index` is out of range. Use [`Self::try_values`] for untrusted indices.
+    pub fn values(&self, leaf_index: usize) -> Vec<Vec<F>> {
+        self.try_values(leaf_index)
+            .expect("batch Merkle leaf index must be in range")
     }
 }
 

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -3,9 +3,10 @@ use alloc::vec::Vec;
 use core::mem::MaybeUninit;
 use core::slice;
 
+use anyhow::{ensure, Result};
 use plonky2_maybe_rayon::*;
 // Re-export MerkleCap from core for unified type across crates
-pub use qp_plonky2_core::MerkleCap;
+pub use qp_plonky2_core::{checked_merkle_cap_len, MerkleCap};
 
 use crate::hash::hash_types::RichField;
 use crate::hash::merkle_proofs::MerkleProof;
@@ -118,28 +119,67 @@ pub(crate) fn fill_digests_buf<F: RichField, H: Hasher<F>>(
     );
 }
 
+#[allow(dead_code)]
 pub(crate) fn merkle_tree_prove<F: RichField, H: Hasher<F>>(
     leaf_index: usize,
     leaves_len: usize,
     cap_height: usize,
     digests: &[H::Hash],
 ) -> Vec<H::Hash> {
-    let num_layers = log2_strict(leaves_len) - cap_height;
-    debug_assert_eq!(leaf_index >> (cap_height + num_layers), 0);
+    try_merkle_tree_prove::<F, H>(leaf_index, leaves_len, cap_height, digests)
+        .expect("Merkle leaf index and tree metadata must be valid")
+}
 
-    let digest_len = 2 * (leaves_len - (1 << cap_height));
-    assert_eq!(digest_len, digests.len());
+pub(crate) fn try_merkle_tree_prove<F: RichField, H: Hasher<F>>(
+    leaf_index: usize,
+    leaves_len: usize,
+    cap_height: usize,
+    digests: &[H::Hash],
+) -> Result<Vec<H::Hash>> {
+    ensure!(
+        leaves_len.is_power_of_two(),
+        "Merkle tree leaf count must be a power of two"
+    );
+    ensure!(leaf_index < leaves_len, "Merkle leaf index is out of range");
+    let cap_len = checked_merkle_cap_len(cap_height)?;
+    ensure!(
+        cap_len <= leaves_len,
+        "Merkle cap height exceeds leaf height"
+    );
+
+    let num_layers = log2_strict(leaves_len) - cap_height;
+    let digest_len = leaves_len
+        .checked_sub(cap_len)
+        .and_then(|n| n.checked_mul(2))
+        .ok_or_else(|| anyhow::anyhow!("Merkle digest length overflow"))?;
+    ensure!(
+        digest_len == digests.len(),
+        "Merkle digest length does not match leaf count and cap height"
+    );
 
     let digest_tree: &[H::Hash] = {
         let tree_index = leaf_index >> num_layers;
         let tree_len = digest_len >> cap_height;
-        &digests[tree_len * tree_index..tree_len * (tree_index + 1)]
+        let tree_start = tree_len
+            .checked_mul(tree_index)
+            .ok_or_else(|| anyhow::anyhow!("Merkle digest tree index overflow"))?;
+        let tree_end = tree_start
+            .checked_add(tree_len)
+            .ok_or_else(|| anyhow::anyhow!("Merkle digest tree range overflow"))?;
+        ensure!(
+            tree_end <= digests.len(),
+            "Merkle digest tree range is out of bounds"
+        );
+        &digests[tree_start..tree_end]
     };
 
     // Mask out high bits to get the index within the sub-tree.
-    let mut pair_index = leaf_index & ((1 << num_layers) - 1);
-    (0..num_layers)
-        .map(|i| {
+    let subtree_len = 1usize
+        .checked_shl(num_layers.try_into().unwrap_or(usize::BITS))
+        .ok_or_else(|| anyhow::anyhow!("Merkle subtree length overflow"))?;
+    let mut pair_index = leaf_index & (subtree_len - 1);
+    let siblings = (0..num_layers)
+        .map(|i| -> Result<H::Hash> {
             let parity = pair_index & 1;
             pair_index >>= 1;
 
@@ -149,14 +189,30 @@ pub(crate) fn merkle_tree_prove<F: RichField, H: Hasher<F>>(
             // `pair_index` is the index of the pair within layer `i`.
             // The index of that the pair within `digests` is
             // `pair_index * 2 ** (i + 1) + (2 ** i - 1)`.
-            let siblings_index = (pair_index << (i + 1)) + (1 << i) - 1;
+            let shifted_pair_index = pair_index
+                .checked_shl((i + 1).try_into().unwrap_or(usize::BITS))
+                .ok_or_else(|| anyhow::anyhow!("Merkle sibling index overflow"))?;
+            let layer_offset = 1usize
+                .checked_shl(i.try_into().unwrap_or(usize::BITS))
+                .and_then(|n| n.checked_sub(1))
+                .ok_or_else(|| anyhow::anyhow!("Merkle sibling layer offset overflow"))?;
+            let siblings_index = shifted_pair_index
+                .checked_add(layer_offset)
+                .ok_or_else(|| anyhow::anyhow!("Merkle sibling index overflow"))?;
             // We have an index for the _pair_, but we want the index of the _sibling_.
             // Double the pair index to get the index of the left sibling. Conditionally add `1`
             // if we are to retrieve the right sibling.
-            let sibling_index = 2 * siblings_index + (1 - parity);
-            digest_tree[sibling_index]
+            let sibling_index = siblings_index
+                .checked_mul(2)
+                .and_then(|n| n.checked_add(1 - parity))
+                .ok_or_else(|| anyhow::anyhow!("Merkle sibling index overflow"))?;
+            digest_tree
+                .get(sibling_index)
+                .copied()
+                .ok_or_else(|| anyhow::anyhow!("Merkle sibling index is out of bounds"))
         })
-        .collect()
+        .collect::<Result<Vec<_>>>()?;
+    Ok(siblings)
 }
 
 impl<F: RichField, H: Hasher<F>> MerkleTree<F, H> {
@@ -193,17 +249,43 @@ impl<F: RichField, H: Hasher<F>> MerkleTree<F, H> {
         }
     }
 
+    pub fn try_get(&self, i: usize) -> Result<&[F]> {
+        self.leaves
+            .get(i)
+            .map(Vec::as_slice)
+            .ok_or_else(|| anyhow::anyhow!("Merkle leaf index is out of range"))
+    }
+
+    /// Return a leaf by index.
+    ///
+    /// Panics if `i` is out of range. Use [`Self::try_get`] for untrusted indices.
     pub fn get(&self, i: usize) -> &[F] {
-        &self.leaves[i]
+        self.try_get(i).expect("Merkle leaf index must be in range")
     }
 
     /// Create a Merkle proof from a leaf index.
-    pub fn prove(&self, leaf_index: usize) -> MerkleProof<F, H> {
+    pub fn try_prove(&self, leaf_index: usize) -> Result<MerkleProof<F, H>> {
+        ensure!(
+            !self.cap.is_empty() && self.cap.len().is_power_of_two(),
+            "Merkle cap must be non-empty and power-of-two sized"
+        );
         let cap_height = log2_strict(self.cap.len());
-        let siblings =
-            merkle_tree_prove::<F, H>(leaf_index, self.leaves.len(), cap_height, &self.digests);
+        let siblings = try_merkle_tree_prove::<F, H>(
+            leaf_index,
+            self.leaves.len(),
+            cap_height,
+            &self.digests,
+        )?;
 
-        MerkleProof { siblings }
+        Ok(MerkleProof { siblings })
+    }
+
+    /// Create a Merkle proof from a leaf index.
+    ///
+    /// Panics if `leaf_index` is out of range. Use [`Self::try_prove`] for untrusted indices.
+    pub fn prove(&self, leaf_index: usize) -> MerkleProof<F, H> {
+        self.try_prove(leaf_index)
+            .expect("Merkle leaf index must be in range")
     }
 }
 

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -741,6 +741,10 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         }
     }
 
+    pub fn try_push_context(&mut self, level: log::Level, ctx: &str) -> Result<(), &'static str> {
+        self.context_log.try_push(ctx, level, self.num_gates())
+    }
+
     pub fn push_context(&mut self, level: log::Level, ctx: &str) {
         self.context_log.push(ctx, level, self.num_gates());
     }

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -251,6 +251,10 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         self.config
             .check_reducing_widths::<D>()
             .expect("Invalid circuit config");
+        self.config
+            .fri_config
+            .required_proof_of_work_leading_zeros::<F>()
+            .expect("Invalid FRI proof-of-work bits");
 
         let &CircuitConfig {
             security_bits,

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -252,6 +252,9 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             .check_reducing_widths::<D>()
             .expect("Invalid circuit config");
         self.config
+            .check_extension_gate_widths::<D>()
+            .expect("Invalid circuit config");
+        self.config
             .fri_config
             .required_proof_of_work_leading_zeros::<F>()
             .expect("Invalid FRI proof-of-work bits");

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -1,7 +1,7 @@
 //! Logic for building plonky2 circuits.
 
 #[cfg(not(feature = "std"))]
-use alloc::{collections::BTreeMap, sync::Arc, vec, vec::Vec};
+use alloc::{collections::BTreeMap, string::String, sync::Arc, vec, vec::Vec};
 use core::cmp::max;
 #[cfg(feature = "std")]
 use std::{collections::BTreeMap, sync::Arc};

--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -18,7 +18,7 @@ use core::ops::{Range, RangeFrom};
 #[cfg(feature = "std")]
 use std::collections::BTreeMap;
 
-use anyhow::Result;
+use anyhow::{ensure, Result};
 pub use qp_plonky2_core::CircuitConfig;
 use qp_plonky2_core::ZkMode;
 use serde::Serialize;
@@ -35,8 +35,8 @@ use crate::fri::structure::{
 use crate::fri::FriParams;
 // Re-export CircuitConfig from core
 use crate::gates::gate::{check_gate_id_collisions, GateRef};
-use crate::gates::lookup::Lookup;
-use crate::gates::lookup_table::LookupTable;
+use crate::gates::lookup::{Lookup, LookupGate};
+use crate::gates::lookup_table::{LookupTable, LookupTableGate};
 use crate::gates::selectors::SelectorsInfo;
 use crate::hash::hash_types::{HashOutTarget, MerkleCapTarget, RichField};
 use crate::hash::merkle_tree::MerkleCap;
@@ -369,6 +369,113 @@ pub struct ProverOnlyCircuitData<
 impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     ProverOnlyCircuitData<F, C, D>
 {
+    pub fn check_lookup_metadata(&self, common_data: &CommonCircuitData<F, D>) -> Result<()> {
+        let degree = 1usize
+            .checked_shl(common_data.degree_bits().try_into().unwrap_or(usize::BITS))
+            .ok_or_else(|| anyhow::anyhow!("lookup metadata degree bits exceed usize width"))?;
+        let num_wires = common_data.config.num_wires;
+        let num_luts = common_data.luts.len();
+
+        if num_luts == 0 {
+            ensure!(
+                self.lookup_rows.is_empty(),
+                "lookup rows present but common data has no lookup tables"
+            );
+            ensure!(
+                self.lut_to_lookups.is_empty(),
+                "lookup targets present but common data has no lookup tables"
+            );
+            return Ok(());
+        }
+
+        ensure!(
+            common_data.num_lookup_polys != 0,
+            "lookup tables require lookup polynomials"
+        );
+        ensure!(
+            common_data.num_lookup_selectors != 0,
+            "lookup tables require lookup selectors"
+        );
+        ensure!(
+            self.lookup_rows.len() == num_luts,
+            "lookup row count {} does not match lookup table count {}",
+            self.lookup_rows.len(),
+            num_luts
+        );
+        ensure!(
+            self.lut_to_lookups.len() == num_luts,
+            "lookup target count {} does not match lookup table count {}",
+            self.lut_to_lookups.len(),
+            num_luts
+        );
+
+        let num_lookup_slots = LookupGate::num_slots(&common_data.config);
+        let num_lut_slots = LookupTableGate::num_slots(&common_data.config);
+        ensure!(
+            num_lookup_slots != 0,
+            "lookup gate capacity must be non-zero"
+        );
+        ensure!(
+            num_lut_slots != 0,
+            "lookup table gate capacity must be non-zero"
+        );
+
+        for (lut_index, lookup_wire) in self.lookup_rows.iter().enumerate() {
+            let LookupWire {
+                last_lu_gate,
+                last_lut_gate,
+                first_lut_gate,
+            } = *lookup_wire;
+            let lut = &common_data.luts[lut_index];
+            let lookups = &self.lut_to_lookups[lut_index];
+
+            ensure!(!lut.is_empty(), "lookup table {lut_index} is empty");
+            ensure!(
+                !lookups.is_empty(),
+                "lookup table {lut_index} has no lookup targets"
+            );
+            ensure!(
+                last_lu_gate < last_lut_gate,
+                "lookup table {lut_index} has empty or inverted lookup rows"
+            );
+            ensure!(
+                last_lut_gate <= first_lut_gate,
+                "lookup table {lut_index} has empty or inverted table rows"
+            );
+            ensure!(
+                first_lut_gate
+                    .checked_add(1)
+                    .is_some_and(|next_row| next_row < degree),
+                "lookup table {lut_index} table rows exceed trace degree"
+            );
+
+            let actual_lookup_rows = last_lut_gate - last_lu_gate;
+            let expected_lookup_rows = lookups.len().div_ceil(num_lookup_slots);
+            ensure!(
+                actual_lookup_rows == expected_lookup_rows,
+                "lookup table {lut_index} row count {} does not match {} lookup targets",
+                actual_lookup_rows,
+                lookups.len()
+            );
+
+            let actual_lut_rows = first_lut_gate - last_lut_gate + 1;
+            let expected_lut_rows = lut.len().div_ceil(num_lut_slots);
+            ensure!(
+                actual_lut_rows == expected_lut_rows,
+                "lookup table {lut_index} table row count {} does not match {} table entries",
+                actual_lut_rows,
+                lut.len()
+            );
+
+            for &(input, output) in lookups {
+                validate_prover_target(input, num_wires, degree, self.representative_map.len())?;
+                validate_prover_target(output, num_wires, degree, self.representative_map.len())?;
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn to_bytes(
         &self,
         generator_serializer: &dyn WitnessGeneratorSerializer<F, D>,
@@ -387,6 +494,37 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         let mut buffer = Buffer::new(bytes);
         buffer.read_prover_only_circuit_data(generator_serializer, common_data)
     }
+}
+
+fn validate_prover_target(
+    target: Target,
+    num_wires: usize,
+    degree: usize,
+    representative_len: usize,
+) -> Result<()> {
+    let index = match target {
+        Target::Wire(wire) => {
+            ensure!(wire.row < degree, "wire target row is outside the trace");
+            ensure!(
+                wire.column < num_wires,
+                "wire target column is outside the trace"
+            );
+            wire.row
+                .checked_mul(num_wires)
+                .and_then(|row_offset| row_offset.checked_add(wire.column))
+        }
+        Target::VirtualTarget { index } => degree
+            .checked_mul(num_wires)
+            .and_then(|wire_targets| wire_targets.checked_add(index)),
+    }
+    .ok_or_else(|| anyhow::anyhow!("prover target index overflow"))?;
+
+    ensure!(
+        index < representative_len,
+        "prover target index is outside the representative map"
+    );
+
+    Ok(())
 }
 
 /// Circuit data required by the verifier, but not the prover.

--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -476,6 +476,10 @@ impl<F: RichField + Extendable<D>, const D: usize> CommonCircuitData<F, D> {
         self.fri_params
             .check_valid()
             .map_err(|_| "invalid FRI params")?;
+        self.config
+            .fri_config
+            .required_proof_of_work_leading_zeros::<F>()
+            .map_err(|_| "invalid FRI proof-of-work bits")?;
 
         // Quotient degree must fit within FRI rate.
         let quotient_degree_bits = log2_ceil(self.quotient_degree_factor);

--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -473,6 +473,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CommonCircuitData<F, D> {
     pub fn check_valid(&self) -> Result<(), &'static str> {
         self.config.check_valid()?;
         self.config.check_reducing_widths::<D>()?;
+        self.config.check_extension_gate_widths::<D>()?;
         self.fri_params
             .check_valid()
             .map_err(|_| "invalid FRI params")?;

--- a/plonky2/src/plonk/config.rs
+++ b/plonky2/src/plonk/config.rs
@@ -7,6 +7,8 @@
 //! mixing Poseidon internally and truncated Keccak externally.
 
 // Re-export core config types - these are the canonical definitions
+use alloc::vec::Vec;
+
 pub use qp_plonky2_core::config::{
     merkle_node_hash_input, GenericConfig, GenericHashOut, Hasher, KeccakGoldilocksConfig,
     PoseidonGoldilocksConfig, MERKLE_LEAF_DOMAIN_TAG, MERKLE_NODE_DOMAIN_TAG,

--- a/plonky2/src/plonk/config.rs
+++ b/plonky2/src/plonk/config.rs
@@ -7,6 +7,7 @@
 //! mixing Poseidon internally and truncated Keccak externally.
 
 // Re-export core config types - these are the canonical definitions
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 pub use qp_plonky2_core::config::{

--- a/plonky2/src/plonk/prover.rs
+++ b/plonky2/src/plonk/prover.rs
@@ -140,6 +140,7 @@ where
     common_data
         .check_valid()
         .map_err(|err| anyhow::anyhow!("invalid common circuit data: {err}"))?;
+    prover_data.check_lookup_metadata(common_data)?;
     let partition_witness = timed!(
         timing,
         &format!("run {} generators", prover_data.generators.len()),
@@ -166,6 +167,7 @@ where
     common_data
         .check_valid()
         .map_err(|err| anyhow::anyhow!("invalid common circuit data: {err}"))?;
+    prover_data.check_lookup_metadata(common_data)?;
     let has_lookup = !common_data.luts.is_empty();
     let config = &common_data.config;
     let num_challenges = config.num_challenges;

--- a/plonky2/src/recursion/cyclic_recursion.rs
+++ b/plonky2/src/recursion/cyclic_recursion.rs
@@ -4,6 +4,7 @@
 use alloc::vec::Vec;
 
 use anyhow::{anyhow, ensure, Result};
+use qp_plonky2_core::checked_merkle_cap_len;
 
 use crate::field::extension::Extendable;
 use crate::hash::hash_types::{HashOut, HashOutTarget, MerkleCapTarget, RichField};
@@ -15,7 +16,7 @@ use crate::plonk::circuit_data::{
 };
 use crate::plonk::config::{AlgebraicHasher, GenericConfig};
 use crate::plonk::proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget};
-use crate::util::serialization::{Buffer, IoResult, Read, Write};
+use crate::util::serialization::{Buffer, IoError, IoResult, Read, Write};
 
 impl<C: GenericConfig<D>, const D: usize> VerifierOnlyCircuitData<C, D> {
     fn from_slice(slice: &[C::F], common_data: &CommonCircuitData<C::F, D>) -> Result<Self>
@@ -61,6 +62,19 @@ impl VerifierCircuitTarget {
             constants_sigmas_cap,
             circuit_digest,
         })
+    }
+
+    pub fn from_bytes_with_common_data<F: RichField + Extendable<D>, const D: usize>(
+        bytes: Vec<u8>,
+        common_data: &CommonCircuitData<F, D>,
+    ) -> IoResult<Self> {
+        let target = Self::from_bytes(bytes)?;
+        let expected_len = checked_merkle_cap_len(common_data.config.fri_config.cap_height)
+            .map_err(|_| IoError)?;
+        if target.constants_sigmas_cap.0.len() != expected_len {
+            return Err(IoError);
+        }
+        Ok(target)
     }
 
     fn from_slice<F: RichField + Extendable<D>, const D: usize>(

--- a/plonky2/src/recursion/dummy_circuit.rs
+++ b/plonky2/src/recursion/dummy_circuit.rs
@@ -9,6 +9,7 @@ use anyhow::{anyhow, ensure, Result};
 use hashbrown::HashMap;
 use plonky2_field::extension::Extendable;
 use plonky2_field::polynomial::PolynomialCoeffs;
+use qp_plonky2_core::checked_merkle_cap_len;
 
 use crate::fri::proof::{FriFinalPolys, FriFinalPolysTarget, FriProof, FriProofTarget};
 use crate::fri::{FriConfig, FriFinalPolyLayout, FriParams, FriReductionStrategy};
@@ -379,6 +380,12 @@ where
     fn deserialize(src: &mut Buffer, _common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
         let verifier_data_target = src.read_target_verifier_circuit()?;
         let verifier_data = src.read_verifier_circuit_data(&DefaultGateSerializer)?;
+        let expected_cap_len =
+            checked_merkle_cap_len(verifier_data.common.config.fri_config.cap_height)
+                .map_err(|_| crate::util::serialization::IoError)?;
+        if verifier_data_target.constants_sigmas_cap.0.len() != expected_cap_len {
+            return Err(crate::util::serialization::IoError);
+        }
         let proof_with_pis_target = src.read_target_proof_with_public_inputs()?;
         let proof_with_pis = src.read_proof_with_public_inputs(&verifier_data.common)?;
         Ok(Self {

--- a/plonky2/src/util/context_tree.rs
+++ b/plonky2/src/util/context_tree.rs
@@ -7,6 +7,9 @@ use alloc::{
 
 use log::{log, Level};
 
+pub(crate) const MAX_CONTEXT_NAME_LEN: usize = 256;
+pub(crate) const MAX_CONTEXT_DEPTH: usize = 64;
+
 /// The hierarchy of contexts, and the gate count contributed by each one. Useful for debugging.
 #[derive(Debug)]
 pub(crate) struct ContextTree {
@@ -20,6 +23,10 @@ pub(crate) struct ContextTree {
     exit_gate_count: Option<usize>,
     /// Any child contexts.
     children: Vec<ContextTree>,
+    /// The currently-open non-root context names. Maintained only on the root tree.
+    open_stack: Vec<String>,
+    /// Cached display form of the open context stack.
+    open_stack_display: String,
 }
 
 impl ContextTree {
@@ -30,6 +37,8 @@ impl ContextTree {
             enter_gate_count: 0,
             exit_gate_count: None,
             children: vec![],
+            open_stack: vec![],
+            open_stack_display: "root".to_string(),
         }
     }
 
@@ -40,21 +49,52 @@ impl ContextTree {
 
     /// A description of the stack of currently-open scopes.
     pub fn open_stack(&self) -> String {
-        let mut stack = Vec::new();
-        self.open_stack_helper(&mut stack);
-        stack.join(" > ")
+        self.open_stack_display.clone()
     }
 
-    fn open_stack_helper(&self, stack: &mut Vec<String>) {
-        if self.is_open() {
-            stack.push(self.name.clone());
-            if let Some(last_child) = self.children.last() {
-                last_child.open_stack_helper(stack);
-            }
+    fn bounded_context_name(ctx: &str) -> String {
+        if ctx.len() <= MAX_CONTEXT_NAME_LEN {
+            return ctx.to_string();
+        }
+
+        let mut end = MAX_CONTEXT_NAME_LEN;
+        while !ctx.is_char_boundary(end) {
+            end -= 1;
+        }
+        ctx[..end].to_string()
+    }
+
+    fn refresh_open_stack_display(&mut self) {
+        self.open_stack_display = "root".to_string();
+        for ctx in &self.open_stack {
+            self.open_stack_display.push_str(" > ");
+            self.open_stack_display.push_str(ctx);
         }
     }
 
-    pub fn push(&mut self, ctx: &str, mut level: log::Level, current_gate_count: usize) {
+    pub fn try_push(
+        &mut self,
+        ctx: &str,
+        level: log::Level,
+        current_gate_count: usize,
+    ) -> Result<(), &'static str> {
+        if self.open_stack.len() >= MAX_CONTEXT_DEPTH {
+            return Err("context metadata depth limit exceeded");
+        }
+
+        let ctx = Self::bounded_context_name(ctx);
+        self.push_node(&ctx, level, current_gate_count);
+        self.open_stack.push(ctx);
+        self.refresh_open_stack_display();
+        Ok(())
+    }
+
+    pub fn push(&mut self, ctx: &str, level: log::Level, current_gate_count: usize) {
+        self.try_push(ctx, level, current_gate_count)
+            .expect("context metadata depth limit exceeded")
+    }
+
+    fn push_node(&mut self, ctx: &str, mut level: log::Level, current_gate_count: usize) {
         assert!(self.is_open());
 
         // We don't want a scope's log level to be stronger than that of its parent.
@@ -62,7 +102,7 @@ impl ContextTree {
 
         if let Some(last_child) = self.children.last_mut() {
             if last_child.is_open() {
-                last_child.push(ctx, level, current_gate_count);
+                last_child.push_node(ctx, level, current_gate_count);
                 return;
             }
         }
@@ -73,16 +113,28 @@ impl ContextTree {
             enter_gate_count: current_gate_count,
             exit_gate_count: None,
             children: vec![],
+            open_stack: vec![],
+            open_stack_display: String::new(),
         })
     }
 
     /// Close the deepest open context from this tree.
     pub fn pop(&mut self, current_gate_count: usize) {
+        assert!(
+            !self.open_stack.is_empty(),
+            "attempted to pop context metadata with no open context"
+        );
+        self.pop_node(current_gate_count);
+        self.open_stack.pop();
+        self.refresh_open_stack_display();
+    }
+
+    fn pop_node(&mut self, current_gate_count: usize) {
         assert!(self.is_open());
 
         if let Some(last_child) = self.children.last_mut() {
             if last_child.is_open() {
-                last_child.pop(current_gate_count);
+                last_child.pop_node(current_gate_count);
                 return;
             }
         }
@@ -107,6 +159,8 @@ impl ContextTree {
                 .filter(|c| c.gate_count_delta(current_gate_count) >= min_delta)
                 .map(|c| c.filter(current_gate_count, min_delta))
                 .collect(),
+            open_stack: vec![],
+            open_stack_display: String::new(),
         }
     }
 
@@ -126,6 +180,46 @@ impl ContextTree {
         for child in &self.children {
             child.print_helper(current_gate_count, depth + 1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_names_are_truncated_in_cached_stack() {
+        let mut tree = ContextTree::new();
+        let long_name = "x".repeat(MAX_CONTEXT_NAME_LEN + 1024);
+
+        tree.try_push(&long_name, Level::Debug, 0).unwrap();
+        let stack = tree.open_stack();
+
+        assert!(stack.starts_with("root > "));
+        assert_eq!(stack.len(), "root > ".len() + MAX_CONTEXT_NAME_LEN);
+    }
+
+    #[test]
+    fn context_depth_is_bounded() {
+        let mut tree = ContextTree::new();
+        for _ in 0..MAX_CONTEXT_DEPTH {
+            tree.try_push("ctx", Level::Debug, 0).unwrap();
+        }
+
+        assert!(tree.try_push("ctx", Level::Debug, 0).is_err());
+    }
+
+    #[test]
+    fn cached_stack_updates_after_pop() {
+        let mut tree = ContextTree::new();
+        tree.try_push("outer", Level::Debug, 0).unwrap();
+        tree.try_push("inner", Level::Debug, 0).unwrap();
+        assert_eq!(tree.open_stack(), "root > outer > inner");
+
+        tree.pop(0);
+        assert_eq!(tree.open_stack(), "root > outer");
+        tree.pop(0);
+        assert_eq!(tree.open_stack(), "root");
     }
 }
 

--- a/plonky2/src/util/serialization/mod.rs
+++ b/plonky2/src/util/serialization/mod.rs
@@ -73,6 +73,13 @@ impl Display for IoError {
 /// A no_std compatible variant of `std::io::Result`
 pub type IoResult<T> = Result<T, IoError>;
 
+/// Maximum Merkle cap height accepted from serialized artifacts.
+///
+/// Height 20 corresponds to 1,048,576 cap hashes, which is already far above normal verifier
+/// target usage and matches the native Merkle-cap deserialization ceiling.
+pub const MAX_DESERIALIZED_MERKLE_CAP_HEIGHT: usize = 20;
+pub const MAX_DESERIALIZED_MERKLE_CAP_LEN: usize = 1 << MAX_DESERIALIZED_MERKLE_CAP_HEIGHT;
+
 /// Creates a Vec with the requested capacity, returning IoError if allocation fails.
 /// This prevents panics from malicious/malformed input specifying huge lengths.
 #[inline]
@@ -344,11 +351,7 @@ pub trait Read {
         F: RichField,
         H: Hasher<F>,
     {
-        // Validate cap_height to prevent exponential allocation attacks.
-        // cap_height of 20 = 1M hashes, which is already very large.
-        // Typical values are 0-16 in practice.
-        const MAX_CAP_HEIGHT: usize = 20;
-        if cap_height > MAX_CAP_HEIGHT {
+        if cap_height > MAX_DESERIALIZED_MERKLE_CAP_HEIGHT {
             return Err(IoError);
         }
         let cap_length = 1 << cap_height;
@@ -363,6 +366,9 @@ pub trait Read {
     #[inline]
     fn read_target_merkle_cap(&mut self) -> IoResult<MerkleCapTarget> {
         let length = self.read_usize()?;
+        if length > MAX_DESERIALIZED_MERKLE_CAP_LEN {
+            return Err(IoError);
+        }
         let mut result = try_with_capacity(length)?;
         for _ in 0..length {
             result.push(self.read_target_hash()?);

--- a/plonky2/src/util/serialization/mod.rs
+++ b/plonky2/src/util/serialization/mod.rs
@@ -1054,7 +1054,7 @@ pub trait Read {
             lut_to_lookups.push(self.read_target_lut()?);
         }
 
-        Ok(ProverOnlyCircuitData {
+        let prover_only = ProverOnlyCircuitData {
             generators,
             generator_indices_by_watches,
             constants_sigmas_commitment,
@@ -1066,7 +1066,12 @@ pub trait Read {
             circuit_digest,
             lookup_rows,
             lut_to_lookups,
-        })
+        };
+        prover_only
+            .check_lookup_metadata(common_data)
+            .map_err(|_| IoError)?;
+
+        Ok(prover_only)
     }
 
     fn read_prover_circuit_data<

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -21,9 +21,11 @@ use plonky2::fri::{
     validate_batch_fri_auxiliary_shape, validate_fri_auxiliary_shape, FriBatchMaskingParams,
     FriChallenger, FriConfig, FriFinalPolyLayout, FriParams, FriReductionStrategy,
 };
+use plonky2::gates::arithmetic_extension::ArithmeticExtensionGate;
 use plonky2::gates::coset_interpolation::CosetInterpolationGate;
 use plonky2::gates::exponentiation::ExponentiationGate;
 use plonky2::gates::gate::{Gate, GateRef};
+use plonky2::gates::multiplication_extension::MulExtensionGate;
 use plonky2::gates::noop::NoopGate;
 use plonky2::gates::reducing::ReducingGate;
 use plonky2::gates::reducing_extension::ReducingExtensionGate;
@@ -1163,6 +1165,32 @@ fn random_access_alias_rejected() -> anyhow::Result<()> {
     let proof = data.prove(pw)?;
     assert_eq!(proof.public_inputs, vec![F::from_canonical_u64(4)]);
     data.verify(proof)
+}
+
+#[test]
+fn insufficient_routed_wires_rejected() {
+    let mut no_mul_config = CircuitConfig::standard_recursion_config();
+    no_mul_config.num_routed_wires = 3 * D - 1;
+    assert!(no_mul_config.check_extension_gate_widths::<D>().is_err());
+    assert!(MulExtensionGate::<D>::try_new_from_config(&no_mul_config).is_err());
+
+    let mut no_arithmetic_config = CircuitConfig::standard_recursion_config();
+    no_arithmetic_config.num_routed_wires = 4 * D - 1;
+    assert!(MulExtensionGate::<D>::try_new_from_config(&no_arithmetic_config).is_ok());
+    assert!(ArithmeticExtensionGate::<D>::try_new_from_config(&no_arithmetic_config).is_err());
+    assert!(no_arithmetic_config
+        .check_extension_gate_widths::<D>()
+        .is_err());
+
+    let standard = CircuitConfig::standard_recursion_config();
+    assert!(standard.check_extension_gate_widths::<D>().is_ok());
+    assert!(ArithmeticExtensionGate::<D>::try_new_from_config(&standard).is_ok());
+    assert!(MulExtensionGate::<D>::try_new_from_config(&standard).is_ok());
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let _ = CircuitBuilder::<F, D>::new(no_arithmetic_config);
+    }));
+    assert!(result.is_err());
 }
 
 #[test]

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -1194,6 +1194,37 @@ fn insufficient_routed_wires_rejected() {
 }
 
 #[test]
+fn forged_lookup_rows_returns_err_not_panic() -> anyhow::Result<()> {
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let input = builder.add_virtual_target();
+    let table = std::sync::Arc::new(vec![(0u16, 10u16), (1u16, 11u16)]);
+    let table_index = builder.add_lookup_table_from_pairs(table);
+    let output = builder.add_lookup_from_index(input, table_index);
+    builder.register_public_input(input);
+    builder.register_public_input(output);
+
+    let mut data = builder.build::<C>();
+    let mut valid = PartialWitness::new();
+    valid.set_target(input, F::ONE)?;
+
+    let proof = data.prove(valid.clone())?;
+    assert_eq!(proof.public_inputs, vec![F::ONE, F::from_canonical_u16(11)]);
+    data.verify(proof)?;
+
+    let degree = data.common.degree();
+    assert!(!data.prover_only.lookup_rows.is_empty());
+    data.prover_only.lookup_rows[0].first_lut_gate = degree;
+
+    let mut timing = TimingTree::default();
+    let err = prove(&data.prover_only, &data.common, valid, &mut timing)
+        .expect_err("forged lookup rows must be rejected");
+    assert!(err.to_string().contains("lookup table 0"));
+
+    Ok(())
+}
+
+#[test]
 fn merkle_poseidon_zero_suffix_leaf_collision_rejected() -> anyhow::Result<()> {
     let leaf = vec![
         F::from_canonical_u64(1),

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -28,7 +28,10 @@ use plonky2::gates::noop::NoopGate;
 use plonky2::gates::reducing::ReducingGate;
 use plonky2::gates::reducing_extension::ReducingExtensionGate;
 use plonky2::gates::util::StridedConstraintConsumer;
-use plonky2::hash::merkle_proofs::{verify_merkle_proof_to_cap, MerkleProof, MerkleProofTarget};
+use plonky2::hash::batch_merkle_tree::BatchMerkleTree;
+use plonky2::hash::merkle_proofs::{
+    verify_batch_merkle_proof_to_cap, verify_merkle_proof_to_cap, MerkleProof, MerkleProofTarget,
+};
 use plonky2::hash::merkle_tree::{MerkleCap, MerkleTree};
 use plonky2::hash::poseidon::PoseidonHash;
 use plonky2::hash::poseidon2::Poseidon2Hash;
@@ -984,6 +987,39 @@ fn context_metadata_bounds_rejected_or_truncated() -> anyhow::Result<()> {
 
     let proof = data.prove(pw)?;
     data.verify(proof)
+}
+
+#[test]
+fn unchecked_leaf_index_returns_err_not_panic() -> anyhow::Result<()> {
+    let leaves = vec![
+        vec![F::ZERO],
+        vec![F::ONE],
+        vec![F::TWO],
+        vec![F::from_canonical_u64(3)],
+    ];
+    let tree = MerkleTree::<F, H>::new(leaves.clone(), 0);
+
+    assert!(tree.try_get(leaves.len()).is_err());
+    assert!(tree.try_prove(leaves.len()).is_err());
+
+    let proof = tree.try_prove(2)?;
+    verify_merkle_proof_to_cap(leaves[2].clone(), 2, &tree.cap, &proof)?;
+
+    let short_leaves = vec![vec![F::ZERO], vec![F::ONE]];
+    let batch_tree = BatchMerkleTree::<F, H>::new(vec![leaves.clone(), short_leaves], 0);
+
+    assert!(batch_tree.try_values(leaves.len()).is_err());
+    assert!(batch_tree.try_open_batch(leaves.len()).is_err());
+
+    let opened_values = batch_tree.try_values(3)?;
+    let batch_proof = batch_tree.try_open_batch(3)?;
+    verify_batch_merkle_proof_to_cap(
+        &opened_values,
+        &batch_tree.leaf_heights,
+        3,
+        &batch_tree.cap,
+        &batch_proof,
+    )
 }
 
 #[test]

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -1023,6 +1023,47 @@ fn unchecked_leaf_index_returns_err_not_panic() -> anyhow::Result<()> {
 }
 
 #[test]
+fn leading_zero_underflow_rejected() -> anyhow::Result<()> {
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let all_zero = builder.add_virtual_target();
+    let unconstrained_width = builder.add_virtual_target();
+
+    assert!(builder.try_assert_leading_zeros(all_zero, 65).is_err());
+    assert!(builder.try_assert_leading_zeros(all_zero, 64).is_ok());
+    assert!(builder
+        .try_assert_leading_zeros(unconstrained_width, 0)
+        .is_ok());
+
+    let data = builder.build::<C>();
+    let mut pw = PartialWitness::new();
+    pw.set_target(all_zero, F::ZERO)?;
+    pw.set_target(unconstrained_width, F::from_canonical_u64(42))?;
+    let proof = data.prove(pw)?;
+    data.verify(proof)?;
+
+    let mut invalid_config = CircuitConfig::standard_recursion_config();
+    invalid_config.fri_config.proof_of_work_bits = 65;
+    assert!(invalid_config.check_valid().is_err());
+    assert!(invalid_config
+        .fri_config
+        .required_proof_of_work_leading_zeros::<F>()
+        .is_err());
+
+    let mut valid_config = CircuitConfig::standard_recursion_config();
+    valid_config.fri_config.proof_of_work_bits = 0;
+    let field_padding = u64::BITS as u32 - F::order().bits() as u32;
+    assert_eq!(
+        valid_config
+            .fri_config
+            .required_proof_of_work_leading_zeros::<F>()?,
+        field_padding
+    );
+
+    Ok(())
+}
+
+#[test]
 fn merkle_poseidon_zero_suffix_leaf_collision_rejected() -> anyhow::Result<()> {
     let leaf = vec![
         F::from_canonical_u64(1),

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -954,6 +954,39 @@ fn verifier_target_deserialization_rejects_oversized_cap() {
 }
 
 #[test]
+fn context_metadata_bounds_rejected_or_truncated() -> anyhow::Result<()> {
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+
+    for _ in 0..64 {
+        builder.try_push_context(log::Level::Debug, "ctx").unwrap();
+    }
+    assert!(builder
+        .try_push_context(log::Level::Debug, "one-context-too-deep")
+        .is_err());
+    for _ in 0..64 {
+        builder.pop_context();
+    }
+
+    let long_name = "x".repeat(100_000);
+    builder
+        .try_push_context(log::Level::Debug, &long_name)
+        .unwrap();
+    let a = builder.add_virtual_target();
+    let b = builder.add_virtual_target();
+    builder.connect(a, b);
+    builder.pop_context();
+
+    let data = builder.build::<C>();
+    let mut pw = PartialWitness::new();
+    pw.set_target(a, F::from_canonical_u64(7))?;
+    pw.set_target(b, F::from_canonical_u64(7))?;
+
+    let proof = data.prove(pw)?;
+    data.verify(proof)
+}
+
+#[test]
 fn merkle_poseidon_zero_suffix_leaf_collision_rejected() -> anyhow::Result<()> {
     let leaf = vec![
         F::from_canonical_u64(1),

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -38,7 +38,9 @@ use plonky2::iop::generator::WitnessGeneratorRef;
 use plonky2::iop::target::Target;
 use plonky2::iop::witness::{PartialWitness, Witness, WitnessWrite};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
-use plonky2::plonk::circuit_data::{CircuitConfig, CommonCircuitData, ProverOnlyCircuitData};
+use plonky2::plonk::circuit_data::{
+    CircuitConfig, CommonCircuitData, ProverOnlyCircuitData, VerifierCircuitTarget,
+};
 use plonky2::plonk::config::{GenericConfig, Hasher, PoseidonGoldilocksConfig};
 use plonky2::plonk::proof::{OpeningSetTarget, ProofTarget, ProofWithPublicInputsTarget};
 use plonky2::plonk::prover::prove;
@@ -48,6 +50,7 @@ use plonky2::recursion::dummy_circuit::{try_cyclic_base_proof, try_dummy_circuit
 use plonky2::util::reducing::ReducingFactorTarget;
 use plonky2::util::serialization::{
     Buffer, DefaultGateSerializer, DefaultGeneratorSerializer, IoResult, Write,
+    MAX_DESERIALIZED_MERKLE_CAP_LEN,
 };
 use plonky2::util::strided_view::PackedStridedView;
 use plonky2::util::timing::TimingTree;
@@ -921,6 +924,33 @@ fn malformed_config_panics_reductions_rejected() -> anyhow::Result<()> {
     let data = builder.build::<C>();
     let proof = data.prove(PartialWitness::new())?;
     data.verify(proof)
+}
+
+#[test]
+fn verifier_target_deserialization_rejects_oversized_cap() {
+    let mut malicious = Vec::new();
+    malicious
+        .write_usize(MAX_DESERIALIZED_MERKLE_CAP_LEN + 1)
+        .unwrap();
+    assert!(VerifierCircuitTarget::from_bytes(malicious).is_err());
+
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+    let verifier_target = builder.add_virtual_verifier_data(config.fri_config.cap_height);
+    let common = builder.build::<C>().common;
+
+    let bytes = verifier_target.to_bytes().unwrap();
+    let decoded =
+        VerifierCircuitTarget::from_bytes_with_common_data::<F, D>(bytes, &common).unwrap();
+    assert_eq!(decoded, verifier_target);
+
+    let mut wrong_len = verifier_target.clone();
+    wrong_len.constants_sigmas_cap.0.pop();
+    let wrong_len_bytes = wrong_len.to_bytes().unwrap();
+    assert!(
+        VerifierCircuitTarget::from_bytes_with_common_data::<F, D>(wrong_len_bytes, &common)
+            .is_err()
+    );
 }
 
 #[test]

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -13,11 +13,11 @@ use plonky2::fri::proof::{
     FriChallenges, FriFinalPolys, FriFinalPolysTarget, FriInitialTreeProof, FriProof,
     FriProofTarget, FriQueryRound,
 };
+use plonky2::fri::structure::{
+    FriBatchInfo, FriInstanceInfo, FriOpeningBatch, FriOpeningExpression, FriOpenings,
+    FriOracleInfo, FriPolynomialInfo,
+};
 use plonky2::fri::{
-    structure::{
-        FriBatchInfo, FriInstanceInfo, FriOpeningBatch, FriOpeningExpression, FriOpenings,
-        FriOracleInfo, FriPolynomialInfo,
-    },
     validate_batch_fri_auxiliary_shape, validate_fri_auxiliary_shape, FriBatchMaskingParams,
     FriChallenger, FriConfig, FriFinalPolyLayout, FriParams, FriReductionStrategy,
 };

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -932,6 +932,45 @@ fn malformed_config_panics_reductions_rejected() -> anyhow::Result<()> {
 }
 
 #[test]
+fn invalid_widths_reduction_rejected() -> anyhow::Result<()> {
+    let mut malformed = CircuitConfig::standard_recursion_config();
+    malformed.num_wires = 7;
+    malformed.num_routed_wires = 7;
+
+    assert_eq!(
+        ReducingGate::<D>::max_coeffs_len(malformed.num_wires, malformed.num_routed_wires),
+        Some(1)
+    );
+    assert_eq!(
+        ReducingExtensionGate::<D>::max_coeffs_len(malformed.num_wires, malformed.num_routed_wires),
+        None
+    );
+    assert!(malformed.check_reducing_widths::<D>().is_err());
+
+    let builder_result = catch_unwind(AssertUnwindSafe(|| {
+        let _ = CircuitBuilder::<F, D>::new(malformed);
+    }));
+    assert!(
+        builder_result.is_err(),
+        "zero-capacity extension reducing gates must be rejected at builder construction"
+    );
+
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let alpha = builder.constant_extension(FF::from_canonical_u64(3));
+    let mut reducer = ReducingFactorTarget::new(alpha);
+    let extension_terms = (0..80)
+        .map(|i| builder.constant_extension(FF::from_canonical_usize(i)))
+        .collect::<Vec<_>>();
+    let reduced = reducer.reduce(&extension_terms, &mut builder);
+    builder.register_public_inputs(&reduced.to_target_array());
+
+    let data = builder.build::<C>();
+    let proof = data.prove(PartialWitness::new())?;
+    data.verify(proof)
+}
+
+#[test]
 fn verifier_target_deserialization_rejects_oversized_cap() {
     let mut malicious = Vec::new();
     malicious

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -1064,6 +1064,34 @@ fn leading_zero_underflow_rejected() -> anyhow::Result<()> {
 }
 
 #[test]
+fn split_low_high_widths_rejected() -> anyhow::Result<()> {
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let x = builder.add_virtual_target();
+
+    let gates_before = builder.num_gates();
+    assert!(builder.try_split_low_high(x, 9, 8).is_err());
+    assert_eq!(builder.num_gates(), gates_before);
+    assert!(builder.try_split_low_high(x, 64, 64).is_err());
+    assert_eq!(builder.num_gates(), gates_before);
+
+    let (low, high) = builder.try_split_low_high(x, 4, 8)?;
+    builder.register_public_input(low);
+    builder.register_public_input(high);
+
+    let data = builder.build::<C>();
+    let mut pw = PartialWitness::new();
+    pw.set_target(x, F::from_canonical_u64(0xab))?;
+
+    let proof = data.prove(pw)?;
+    assert_eq!(
+        proof.public_inputs,
+        vec![F::from_canonical_u64(0xb), F::from_canonical_u64(0xa)]
+    );
+    data.verify(proof)
+}
+
+#[test]
 fn merkle_poseidon_zero_suffix_leaf_collision_rejected() -> anyhow::Result<()> {
     let leaf = vec![
         F::from_canonical_u64(1),

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -1092,6 +1092,34 @@ fn split_low_high_widths_rejected() -> anyhow::Result<()> {
 }
 
 #[test]
+fn zero_bit_range_check_rejects_nonzero() -> anyhow::Result<()> {
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let x = builder.add_virtual_target();
+    builder.range_check(x, 0);
+
+    let one_bit = builder.add_virtual_target();
+    builder.range_check(one_bit, 1);
+
+    let data = builder.build::<C>();
+
+    let mut valid = PartialWitness::new();
+    valid.set_target(x, F::ZERO)?;
+    valid.set_target(one_bit, F::ONE)?;
+    let proof = data.prove(valid)?;
+    data.verify(proof)?;
+
+    let mut invalid = PartialWitness::new();
+    invalid.set_target(x, F::ONE)?;
+    invalid.set_target(one_bit, F::ONE)?;
+    let result = catch_unwind(AssertUnwindSafe(|| data.prove(invalid)));
+    assert!(result.is_ok(), "zero-bit range check must not panic");
+    assert!(result.unwrap().is_err());
+
+    Ok(())
+}
+
+#[test]
 fn merkle_poseidon_zero_suffix_leaf_collision_rejected() -> anyhow::Result<()> {
     let leaf = vec![
         F::from_canonical_u64(1),

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -1120,6 +1120,52 @@ fn zero_bit_range_check_rejects_nonzero() -> anyhow::Result<()> {
 }
 
 #[test]
+fn random_access_alias_rejected() -> anyhow::Result<()> {
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let access_index = builder.add_virtual_target();
+    let values = vec![
+        builder.constant(F::from_canonical_u64(10)),
+        builder.constant(F::from_canonical_u64(20)),
+        builder.constant(F::from_canonical_u64(30)),
+    ];
+    let selected = builder.random_access(access_index, values);
+    builder.register_public_input(selected);
+
+    let data = builder.build::<C>();
+
+    let mut valid = PartialWitness::new();
+    valid.set_target(access_index, F::from_canonical_usize(2))?;
+    let proof = data.prove(valid)?;
+    assert_eq!(proof.public_inputs, vec![F::from_canonical_u64(30)]);
+    data.verify(proof)?;
+
+    let mut invalid = PartialWitness::new();
+    invalid.set_target(access_index, F::from_canonical_usize(3))?;
+    let result = catch_unwind(AssertUnwindSafe(|| data.prove(invalid)));
+    assert!(result.is_ok(), "out-of-range random access must not panic");
+    assert!(result.unwrap().is_err());
+
+    let config = CircuitConfig::standard_recursion_config();
+    let mut power_two_builder = CircuitBuilder::<F, D>::new(config);
+    let index = power_two_builder.add_virtual_target();
+    let values = vec![
+        power_two_builder.constant(F::from_canonical_u64(1)),
+        power_two_builder.constant(F::from_canonical_u64(2)),
+        power_two_builder.constant(F::from_canonical_u64(3)),
+        power_two_builder.constant(F::from_canonical_u64(4)),
+    ];
+    let selected = power_two_builder.random_access(index, values);
+    power_two_builder.register_public_input(selected);
+    let data = power_two_builder.build::<C>();
+    let mut pw = PartialWitness::new();
+    pw.set_target(index, F::from_canonical_usize(3))?;
+    let proof = data.prove(pw)?;
+    assert_eq!(proof.public_inputs, vec![F::from_canonical_u64(4)]);
+    data.verify(proof)
+}
+
+#[test]
 fn merkle_poseidon_zero_suffix_leaf_collision_rejected() -> anyhow::Result<()> {
     let leaf = vec![
         F::from_canonical_u64(1),

--- a/verifier/src/gates/arithmetic_extension.rs
+++ b/verifier/src/gates/arithmetic_extension.rs
@@ -19,10 +19,21 @@ pub struct ArithmeticExtensionGate<const D: usize> {
 }
 
 impl<const D: usize> ArithmeticExtensionGate<D> {
-    pub const fn new_from_config(config: &CircuitConfig) -> Self {
-        Self {
-            num_ops: Self::num_ops(config),
+    pub fn try_new_from_config(config: &CircuitConfig) -> core::result::Result<Self, &'static str> {
+        let num_ops = Self::num_ops(config);
+        if num_ops == 0 {
+            return Err("not enough routed wires for arithmetic extension gate");
         }
+        Ok(Self { num_ops })
+    }
+
+    pub const fn new_from_config(config: &CircuitConfig) -> Self {
+        let num_ops = Self::num_ops(config);
+        assert!(
+            num_ops > 0,
+            "not enough routed wires for arithmetic extension gate"
+        );
+        Self { num_ops }
     }
 
     /// Determine the maximum number of operations that can fit in one gate for the given config.

--- a/verifier/src/gates/multiplication_extension.rs
+++ b/verifier/src/gates/multiplication_extension.rs
@@ -19,10 +19,21 @@ pub struct MulExtensionGate<const D: usize> {
 }
 
 impl<const D: usize> MulExtensionGate<D> {
-    pub const fn new_from_config(config: &CircuitConfig) -> Self {
-        Self {
-            num_ops: Self::num_ops(config),
+    pub fn try_new_from_config(config: &CircuitConfig) -> core::result::Result<Self, &'static str> {
+        let num_ops = Self::num_ops(config);
+        if num_ops == 0 {
+            return Err("not enough routed wires for multiplication extension gate");
         }
+        Ok(Self { num_ops })
+    }
+
+    pub const fn new_from_config(config: &CircuitConfig) -> Self {
+        let num_ops = Self::num_ops(config);
+        assert!(
+            num_ops > 0,
+            "not enough routed wires for multiplication extension gate"
+        );
+        Self { num_ops }
     }
 
     /// Determine the maximum number of operations that can fit in one gate for the given config.

--- a/verifier/src/gates/reducing.rs
+++ b/verifier/src/gates/reducing.rs
@@ -2,6 +2,8 @@
 use alloc::{format, string::String, vec::Vec};
 use core::ops::Range;
 
+use qp_plonky2_core::circuit_config::reducing_base_capacity;
+
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::gates::gate::VerificationGate;
 use crate::gates::util::StridedConstraintConsumer;
@@ -9,7 +11,6 @@ use crate::hash::hash_types::RichField;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::vars::{EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::{Buffer, IoResult, Read, Write};
-use qp_plonky2_core::circuit_config::reducing_base_capacity;
 
 /// Computes `sum alpha^i c_i` for a vector `c_i` of `num_coeffs` elements of the base field.
 #[derive(Debug, Default, Clone)]

--- a/verifier/src/gates/reducing_extension.rs
+++ b/verifier/src/gates/reducing_extension.rs
@@ -2,6 +2,8 @@
 use alloc::{format, string::String, vec::Vec};
 use core::ops::Range;
 
+use qp_plonky2_core::circuit_config::reducing_extension_capacity;
+
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::gates::gate::VerificationGate;
 use crate::gates::util::StridedConstraintConsumer;
@@ -9,7 +11,6 @@ use crate::hash::hash_types::RichField;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::vars::{EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::{Buffer, IoResult, Read, Write};
-use qp_plonky2_core::circuit_config::reducing_extension_capacity;
 
 /// Computes `sum alpha^i c_i` for a vector `c_i` of `num_coeffs` elements of the extension field.
 #[derive(Debug, Clone, Default)]

--- a/verifier/src/hash/batch_merkle_tree.rs
+++ b/verifier/src/hash/batch_merkle_tree.rs
@@ -3,10 +3,10 @@ use alloc::vec;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use itertools::Itertools;
+use anyhow::{ensure, Result};
 use qp_plonky2_core::merkle_proofs::MerkleProof;
 use qp_plonky2_core::merkle_tree::{
-    capacity_up_to_mut, fill_digests_buf, merkle_tree_prove, MerkleCap,
+    capacity_up_to_mut, checked_merkle_cap_len, fill_digests_buf, try_merkle_tree_prove, MerkleCap,
 };
 
 use crate::hash::hash_types::{RichField, NUM_HASH_OUT_ELTS};
@@ -53,7 +53,7 @@ impl<F: RichField, H: Hasher<F>> BatchMerkleTree<F, H> {
         let num_digests = 2 * (leaves_len - (1 << cap_height));
         let mut digests = Vec::with_capacity(num_digests);
         let digests_buf = capacity_up_to_mut(&mut digests, num_digests);
-        let mut digests_buf_pos = 0;
+        let mut digests_buf_pos: usize = 0;
 
         let mut cap = vec![];
         let dummy_leaves = vec![vec![F::ZERO]; 1 << cap_height];
@@ -129,38 +129,122 @@ impl<F: RichField, H: Hasher<F>> BatchMerkleTree<F, H> {
         }
     }
 
+    fn leaf_count(&self) -> Result<usize> {
+        ensure!(!self.leaves.is_empty(), "batch Merkle tree has no leaves");
+        let leaf_count = self.leaves[0].len();
+        ensure!(leaf_count > 0, "batch Merkle tree has no leaf rows");
+        ensure!(
+            leaf_count.is_power_of_two(),
+            "batch Merkle tree leaf count is not a power of two"
+        );
+        Ok(leaf_count)
+    }
+
     /// Create a Merkle proof from a leaf index.
-    pub fn open_batch(&self, leaf_index: usize) -> MerkleProof<F, H> {
-        let mut digests_buf_pos = 0;
-        let initial_leaf_height = log2_strict(self.leaves[0].len());
+    pub fn try_open_batch(&self, leaf_index: usize) -> Result<MerkleProof<F, H>> {
+        let leaf_count = self.leaf_count()?;
+        ensure!(
+            leaf_index < leaf_count,
+            "batch Merkle leaf index is out of range"
+        );
+        ensure!(
+            self.leaf_heights.len() == self.leaves.len(),
+            "batch Merkle leaf height metadata is malformed"
+        );
+        ensure!(
+            !self.cap.is_empty() && self.cap.len().is_power_of_two(),
+            "batch Merkle cap must be non-empty and power-of-two sized"
+        );
+
+        let mut digests_buf_pos: usize = 0;
+        let initial_leaf_height = log2_strict(leaf_count);
         let mut siblings = vec![];
         let mut cap_heights = self.leaf_heights.clone();
         cap_heights.push(log2_strict(self.cap.len()));
         for window in cap_heights.windows(2) {
             let cur_cap_height = window[0];
             let next_cap_height = window[1];
-            let num_digests: usize = 2 * ((1 << cur_cap_height) - (1 << next_cap_height));
-            siblings.extend::<Vec<_>>(merkle_tree_prove::<F, H>(
-                leaf_index >> (initial_leaf_height - cur_cap_height),
-                1 << cur_cap_height,
+            ensure!(
+                cur_cap_height <= initial_leaf_height,
+                "batch Merkle leaf height exceeds initial height"
+            );
+            ensure!(
+                next_cap_height <= cur_cap_height,
+                "batch Merkle cap heights are not descending"
+            );
+            let cur_cap_len = checked_merkle_cap_len(cur_cap_height)?;
+            let next_cap_len = checked_merkle_cap_len(next_cap_height)?;
+            let num_digests = cur_cap_len
+                .checked_sub(next_cap_len)
+                .and_then(|n| n.checked_mul(2))
+                .ok_or_else(|| anyhow::anyhow!("batch Merkle digest length overflow"))?;
+            let digests_end = digests_buf_pos
+                .checked_add(num_digests)
+                .ok_or_else(|| anyhow::anyhow!("batch Merkle digest range overflow"))?;
+            ensure!(
+                digests_end <= self.digests.len(),
+                "batch Merkle digest range is out of bounds"
+            );
+            let shift = initial_leaf_height - cur_cap_height;
+            siblings.extend::<Vec<_>>(try_merkle_tree_prove::<F, H>(
+                leaf_index >> shift,
+                cur_cap_len,
                 next_cap_height,
-                &self.digests[digests_buf_pos..digests_buf_pos + num_digests],
-            ));
+                &self.digests[digests_buf_pos..digests_end],
+            )?);
             digests_buf_pos += num_digests;
         }
+        ensure!(
+            digests_buf_pos == self.digests.len(),
+            "batch Merkle proof did not consume every digest"
+        );
 
-        MerkleProof { siblings }
+        Ok(MerkleProof { siblings })
     }
 
-    pub fn values(&self, leaf_index: usize) -> Vec<Vec<F>> {
-        let leaves_cap_height = log2_strict(self.leaves[0].len());
+    /// Create a Merkle proof from a leaf index.
+    ///
+    /// Panics if `leaf_index` is out of range. Use [`Self::try_open_batch`] for untrusted indices.
+    pub fn open_batch(&self, leaf_index: usize) -> MerkleProof<F, H> {
+        self.try_open_batch(leaf_index)
+            .expect("batch Merkle leaf index must be in range")
+    }
+
+    pub fn try_values(&self, leaf_index: usize) -> Result<Vec<Vec<F>>> {
+        let leaf_count = self.leaf_count()?;
+        ensure!(
+            leaf_index < leaf_count,
+            "batch Merkle leaf index is out of range"
+        );
+        ensure!(
+            self.leaf_heights.len() == self.leaves.len(),
+            "batch Merkle leaf height metadata is malformed"
+        );
+
+        let leaves_cap_height = log2_strict(leaf_count);
         self.leaves
             .iter()
             .zip(&self.leaf_heights)
-            .map(|(leaves, cap_height)| {
-                leaves[leaf_index >> (leaves_cap_height - cap_height)].clone()
+            .map(|(leaves, cap_height)| -> Result<Vec<F>> {
+                ensure!(
+                    *cap_height <= leaves_cap_height,
+                    "batch Merkle leaf height exceeds initial height"
+                );
+                let row = leaf_index >> (leaves_cap_height - cap_height);
+                leaves
+                    .get(row)
+                    .cloned()
+                    .ok_or_else(|| anyhow::anyhow!("batch Merkle leaf row is out of range"))
             })
-            .collect_vec()
+            .collect()
+    }
+
+    /// Return the batch-opened values at a leaf index.
+    ///
+    /// Panics if `leaf_index` is out of range. Use [`Self::try_values`] for untrusted indices.
+    pub fn values(&self, leaf_index: usize) -> Vec<Vec<F>> {
+        self.try_values(leaf_index)
+            .expect("batch Merkle leaf index must be in range")
     }
 }
 

--- a/verifier/src/plonk/circuit_data.rs
+++ b/verifier/src/plonk/circuit_data.rs
@@ -247,6 +247,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CommonVerifierData<F, D> {
     pub fn check_valid(&self) -> Result<(), &'static str> {
         self.config.check_valid()?;
         self.config.check_reducing_widths::<D>()?;
+        self.config.check_extension_gate_widths::<D>()?;
         self.fri_params
             .check_valid()
             .map_err(|_| "invalid FRI params")?;

--- a/verifier/src/plonk/circuit_data.rs
+++ b/verifier/src/plonk/circuit_data.rs
@@ -250,6 +250,10 @@ impl<F: RichField + Extendable<D>, const D: usize> CommonVerifierData<F, D> {
         self.fri_params
             .check_valid()
             .map_err(|_| "invalid FRI params")?;
+        self.config
+            .fri_config
+            .required_proof_of_work_leading_zeros::<F>()
+            .map_err(|_| "invalid FRI proof-of-work bits")?;
 
         // Quotient degree must fit within FRI rate.
         let quotient_degree_bits = crate::util::log2_ceil(self.quotient_degree_factor);


### PR DESCRIPTION
## V12 audit (7/10): medium DoS preconditions & artifact validation

Part of the stack splitting #38 into reviewable slices. Stacked on `v12-audit/06-medium-artifact-validation`.

Addresses **10** V12 audit finding(s):

| Finding | Severity | Title | Commit |
|---|---|---|---|
| #64608 | Medium | Unbounded verifier-target deserialization | `0cf34d74` |
| #64610 | Medium | Unbounded context metadata DoS | `45617b47` |
| #64626 | Medium | Unchecked leaf index panics | `b01081c2` |
| #64630 | Medium | Unchecked leading-zero underflow | `a35babbe` |
| #64633 | Medium | Unchecked widths exhaust circuit builder | `63d70318` |
| #64634 | Medium | Zero-bit checks add no constraint | `58641cce` |
| #64638 | Medium | Out-of-range indices alias last element | `eee642d3` |
| #64641 | Medium | Insufficient routed wires panic | `db4bcebf` |
| #64656 | Medium | Forged lookup rows trigger panics | `5f2123e0` |
| #64663 | Medium | Invalid widths trigger reduction panic | `bc93cacc` |

---

<details>
<summary><b>#64608 · Medium · Unbounded verifier-target deserialization</b></summary>

**Description**

`VerifierCircuitTarget::from_bytes` deserializes a `MerkleCapTarget` from attacker-controlled bytes without any size bound. The underlying `read_target_merkle_cap` reads an arbitrary serialized length, reserves a vector of that size immediately, and only then starts consuming per-element data. Unlike the normal `read_merkle_cap` path for concrete verifier data, this target-side path has no `MAX_CAP_HEIGHT` or equivalent sanity check. A malicious byte stream can therefore force excessive allocation and parsing work before the function returns an error.

**Root cause**

`VerifierCircuitTarget::from_bytes` delegates to `read_target_merkle_cap`, which trusts a serialized vector length for `constants_sigmas_cap` and does not enforce any maximum or derive the expected size from trusted metadata. The deserializer allocates based on attacker-controlled length before proving the buffer actually contains that many entries.

**Impact**

Any service that accepts serialized `VerifierCircuitTarget` values from untrusted sources can be driven into heavy memory consumption or process failure. In embedded verifier/prover environments, this can be used to repeatedly crash or stall the application with crafted inputs.

**Remediation**

_Explanation_

- Validate the serialized `MerkleCapTarget` length inside `read_target_merkle_cap` before any allocation, and reject values above the supported cap bound instead of passing attacker-controlled length to `try_with_capacity`. Mirror the existing `read_merkle_cap` limit so target-side deserialization enforces the same invariant and cannot reserve memory from untrusted size fields.

---

</details>

<details>
<summary><b>#64610 · Medium · Unbounded context metadata DoS</b></summary>

**Description**

`ContextTree` treats caller-provided context names as unbounded data and manages nesting with recursive descent through the deepest open child. `CircuitBuilder::push_context` exposes that machinery publicly, and `connect` eagerly materializes the full open-context chain with `open_stack()` and stores the resulting string in every `CopyConstraint`. The stored `name` is only debugging metadata and is ignored when copy constraints are actually merged, so an attacker can spend almost no semantic circuit work while forcing large recursive walks and heap allocations. A malicious caller can therefore drive stack overflow with very deep nesting, or force memory exhaustion by supplying oversized context strings and then emitting many `connect` calls. Because this is reachable through the public builder API, downstream applications that accept untrusted circuit descriptions can be crashed remotely.

**Root cause**

The file implements context nesting with recursive tree traversal and stores unbounded caller-supplied `ctx` strings verbatim. Adjacent builder code makes this reachable from the public API and copies the full stack into each `CopyConstraint`, even though later circuit construction discards that metadata.

**Impact**

An attacker who can influence circuit construction can terminate the hosting process by pushing a very deep context stack and then invoking any path that walks it, such as another `push_context`, `pop_context`, or `connect`. They can also amplify memory usage dramatically by supplying large context labels, since each `connect` clones and joins the entire open stack into a per-constraint string that is not needed for proof generation.

**Remediation**

_Explanation_

Assumption: `CopyConstraint.name` is debug-only metadata and is not required for proving or verification semantics, because later wire-partition construction ignores it.

- Remove eager context-string materialization from `connect` and stop storing the joined open-context stack in each `CopyConstraint`; keep copy constraints semantic-only, and if context is still needed for diagnostics, derive it lazily at the logging/error site instead of cloning attacker-controlled strings into every constraint.

- Replace recursive deepest-open-child walks in `ContextTree::push`, `pop`, and open-stack collection with iterative traversal of the currently open branch, and enforce explicit bounds on context depth and context-label length at `push_context` so caller-controlled metadata cannot trigger unbounded recursion or heap growth.

---

</details>

<details>
<summary><b>#64626 · Medium · Unchecked leaf index panics</b></summary>

**Description**

`open_batch` and `values` accept an arbitrary `leaf_index` but never verify that it is smaller than the largest leaf layer. `open_batch` forwards the unchecked index into digest slicing logic, while `values` directly indexes each leaf matrix after shifting by the height difference. An out-of-range caller input therefore triggers a panic instead of returning an error. In a proof-serving or RPC integration that exposes batch openings by index, a malicious request can repeatedly crash request handlers or the whole process if panics abort.

**Root cause**

The public accessors trust `leaf_index` to satisfy internal invariants and use panicking slice/index operations instead of validating bounds and returning a fallible result.

**Impact**

Any downstream service that accepts an external query index and calls these APIs can be forced into a denial of service with a single oversized index. Depending on panic strategy and integration, this can tear down the current worker or terminate the full prover/verifier process.

</details>

<details>
<summary><b>#64630 · Medium · Unchecked leading-zero underflow</b></summary>

**Description**

`assert_leading_zeros` converts a leading-zero requirement into a bit-length check by calling `self.range_check(x, (64 - leading_zeros) as usize)`, but it never validates that `leading_zeros <= 64`. If a larger value is supplied, the subtraction underflows before the cast, producing either a panic or a huge `usize` depending on build settings. `range_check` immediately forwards that value to `split_le`, which allocates vectors and gate rows proportional to the requested bit count. In the recursive verifier path, this argument is derived from `FriConfig.proof_of_work_bits`, and the deserializer accepts any `u32` without an upper bound. An attacker who can feed oversized serialized FRI parameters into a service that builds recursive verifier circuits can therefore force a crash or memory-exhaustion path during circuit construction.

**Root cause**

`assert_leading_zeros` performs unchecked subtraction on a user-derived `u32` and assumes the result fits in the 0..=64 range. Adjacent deserialization code accepts arbitrary `proof_of_work_bits` values, so the invariant is not enforced before this method is called.

**Impact**

A downstream verifier service that constructs recursive circuits from untrusted serialized metadata can be crashed or driven into excessive allocation by setting `proof_of_work_bits` above 64. This is a denial-of-service vector against applications that treat serialized circuit/common data as attacker-controlled input.

**Remediation**

_Explanation_

Assume `assert_leading_zeros` is intended to operate only on 64-bit values, as the current `64 - leading_zeros` logic implies.

- Enforce that invariant at the root: reject any `leading_zeros > 64` inside `CircuitBuilder::assert_leading_zeros` and perform the recursive verifier’s `proof_of_work_bits + field-size offset` calculation with checked arithmetic, failing cleanly if the effective requirement exceeds 64 instead of passing an underflowed bit count into `range_check`.

- Validate untrusted `FriConfig` against the same bound before circuit construction. When decoding or accepting serialized config, reject `proof_of_work_bits` values that would make the recursive verifier’s effective leading-zero target exceed 64 for the selected field, so attacker-controlled metadata cannot reach the unchecked path at all.

---

</details>

<details>
<summary><b>#64633 · Medium · Unchecked widths exhaust circuit builder</b></summary>

**Description**

`split_low_high` assumes `n_log <= num_bits` but never enforces that precondition. It immediately evaluates `num_bits - n_log` and forwards the result into `range_check(high, ...)`, which calls `split_le` to allocate `BaseSumGate`s proportional to the requested width. With attacker-controlled bit-width parameters, an oversized `n_log` therefore causes arithmetic overflow on the subtraction path or an enormous wrapped width to flow into gate allocation instead of producing a normal validation error. Downstream applications that compile circuits from untrusted descriptions can be forced into panic or memory/CPU exhaustion during circuit construction.

**Root cause**

`split_low_high` performs `num_bits - n_log` without first checking that `n_log` is within the declared bit-width. The unchecked result is then used as an allocation-driving size parameter in `split_le`.

**Impact**

An attacker who controls bit-width parameters for circuit construction can make the builder abort or consume excessive resources before any proof is generated. This denies service to builders that expose circuit compilation as part of a request flow.

</details>

<details>
<summary><b>#64634 · Medium · Zero-bit checks add no constraint</b></summary>

**Description**

`range_check` delegates entirely to `split_le`, but `split_le` returns immediately when `num_bits == 0` without connecting the target or adding any gate. As a result, `range_check(x, 0)` does not enforce the documented condition `x < 2^0`; it leaves `x` completely unconstrained. `split_low_high` inherits this flaw on boundary splits: when `n_log == 0`, `low` should be forced to zero but is unconstrained, and when `n_log == num_bits`, `high` should be forced to zero but is unconstrained. Any downstream circuit that relies on these boundary cases for decomposition can therefore accept forged witnesses with arbitrary values in the supposedly zero component.

**Root cause**

The zero-bit case is treated as an early-return fast path in `split_le`, and `range_check` has no special handling to turn that case into an explicit zero constraint. `split_low_high` then reuses `range_check` for both halves, so its boundary cases inherit the missing constraint.

**Impact**

A malicious prover can satisfy circuits that rely on zero-bit range checks or boundary-case `split_low_high` decompositions while assigning attacker-chosen values to fields that should be fixed at zero. This can bypass higher-level circuit logic that trusts the returned `low` or `high` components as canonical integer decompositions.

</details>

<details>
<summary><b>#64638 · Medium · Out-of-range indices alias last element</b></summary>

**Description**

`random_access` silently pads any non-power-of-two input vector by repeating its last element until the length is a power of two. The gate is then instantiated against that padded length, and `RandomAccessGate` only proves that `access_index` is a valid `bits`-bit index into the padded array. There is no constraint that `access_index` is smaller than the original vector length. As a result, every index in the padded tail is accepted and resolves to the last real element, so one logical entry can be selected by multiple distinct indices. Any circuit that relies on these helpers for strict in-bounds selection can therefore be bypassed by supplying an out-of-range index that aliases to the final element.

**Root cause**

The helpers normalize non-power-of-two vectors by duplicating the last item instead of constraining the original length bound. `RandomAccessGate` then enforces membership only with respect to the padded `vec_size`, so the original upper bound is lost.

**Impact**

An attacker can satisfy index-based circuit checks with an index that should have been rejected, as long as it falls into the padded range and the target value equals the final real entry. This breaks uniqueness and bounds assumptions around table lookups, and can let a malicious prover select the last verifier key, hash, cap entry, or extension value without proving that the supplied index was actually in range.

**Remediation**

_Explanation_

Assuming `random_access` is intended to enforce strict in-bounds access over the caller’s original vector length, add an explicit circuit constraint that `access_index < current_len` before any power-of-two padding, and keep the duplicated last elements as an unreachable internal implementation detail only. Preserve the original length bound alongside the padded `vec_size`; do not let the gate’s `bits`-bit range check stand in for the caller’s true upper bound.

---

</details>

<details>
<summary><b>#64641 · Medium · Insufficient routed wires panic</b></summary>

**Description**

The extension-arithmetic helpers assume the configured circuit has enough routed wires to host at least one extension arithmetic slot, but they never validate that precondition before allocating gates. `ArithmeticExtensionGate::num_ops` becomes zero when `num_routed_wires < 4 * D`, and `MulExtensionGate::num_ops` becomes zero when `num_routed_wires < 3 * D`. Despite that, `compute_*_operation` still calls `find_slot` and then derives wire ranges for slot `0`, even though the gate has zero capacity. `add_gate` only checks total `num_wires` and constant count, not routed-wire sufficiency, so malformed configs survive until these helpers are invoked and then panic during slot arithmetic or routing assertions. Any application that builds circuits from untrusted configuration or circuit descriptions can therefore be crashed by requesting extension arithmetic under an undersized `CircuitConfig`.

**Root cause**

The file assumes `ArithmeticExtensionGate`/`MulExtensionGate` always have at least one operation slot, but neither `arithmetic_extension` nor the gate-compatibility checks enforce `num_routed_wires >= 4 * D` or `>= 3 * D`. Zero-slot gates are therefore admitted and later used as if they had valid routed wires.

**Impact**

An attacker who can influence circuit construction parameters can trigger deterministic panics during circuit building, preventing the service from compiling or proving the requested circuit. This turns malformed extension-arithmetic requests into an availability attack against builder or prover endpoints that accept untrusted circuit configs or generated circuits.

**Remediation**

_Explanation_

Assume zero-op `ArithmeticExtensionGate` and `MulExtensionGate` instances are invalid configurations, not supported gate variants.

- Reject undersized configs at the extension-arithmetic entry points: require `ArithmeticExtensionGate::num_ops(config) > 0` before `compute_arithmetic_extension_operation` calls `find_slot`, and require `MulExtensionGate::num_ops(config) > 0` before `compute_mul_extension_operation` does the same. Fail fast with a clear circuit-configuration error tied to `num_routed_wires < 4 * D` or `< 3 * D` instead of letting a zero-capacity gate reach slot allocation.

- If those gates can be reached from any other builder path, enforce the same invariant where the gate is constructed or admitted so zero-slot extension gates are never added to a circuit at all; do not try to mask the panic later in `find_slot` or routing, because the invalid state originates from accepting a gate with no valid routed-wire capacity.

---

</details>

<details>
<summary><b>#64656 · Medium · Forged lookup rows trigger panics</b></summary>

**Description**

The lookup selector helpers trust every `LookupWire` index and write directly into `PolynomialValues` without checking that the rows are in-range, ordered, or even correspond to an existing lookup table. `CircuitBuilder::add_lookup_rows` is a public method and simply appends caller-supplied indices, so external code can construct inconsistent lookup metadata. A forged `first_lut_gate`, `last_lut_gate`, or `last_lu_gate` that exceeds the trace length will panic during selector construction, and extra `lookup_rows` entries can also inflate `num_lookup_selectors` beyond the actual number of LUTs. Later verification code indexes `common_data.luts` using that unchecked selector count, so inconsistent metadata can crash proving or verification even after build succeeds. This gives untrusted circuit descriptions a straightforward denial-of-service primitive against applications that expose circuit building or deserialize and execute prover data from outside trust boundaries.

**Root cause**

This file assumes `lookup_rows` is always internally well-formed, but the surrounding API exposes that structure to untrusted callers and never validates the indices or cardinality before using them. The unchecked row writes and selector-count derivation turn malformed lookup metadata into panic paths.

**Impact**

An attacker who can influence lookup metadata can make a prover or verifier panic on demand, either during circuit build from out-of-bounds row writes or later when lookup selector counts exceed the actual LUT list. Services that accept untrusted circuit descriptions or prover artifacts can therefore be taken offline with a single malformed request.

**Remediation**

_Explanation_

Assumption: `lookup_rows` is intended to contain exactly one well-formed `LookupWire` per LUT, and the valid row domain is the built trace length (`gate_instances.len()`).

Reject malformed lookup metadata before selector construction: enforce that every `LookupWire` satisfies the expected row ordering, every referenced row is strictly within the final trace length, and `lookup_rows.len()` exactly matches `self.luts.len()`. Build selectors and set `num_lookup_selectors` only from that validated set, and fail circuit construction on violation instead of accepting inconsistent metadata that later drives unchecked indexing.

---

</details>

<details>
<summary><b>#64663 · Medium · Invalid widths trigger reduction panic</b></summary>

**Description**

`ReducingExtensionGate::max_coeffs_len` assumes the circuit width can fit at least one reduction chunk, but it never validates that assumption. For narrow custom `CircuitConfig`s, integer division can make the returned chunk size `0`, because the formula floors `((num_routed_wires - 3 * D) / D)` or `((num_wires - 2 * D) / (2 * D))`. `ReducingFactorTarget::reduce` then uses that value as a modulus divisor and chunk size without any guard. Since `CircuitBuilder::check_config` only checks FRI security parameters and not wire-layout sanity, attacker-controlled or malformed configs can reach this path unchanged. The result is a deterministic panic during circuit construction instead of a clean validation error.

**Root cause**

`max_coeffs_len` derives a chunk size from unvalidated width parameters and may return `0`, while its caller assumes the result is a valid positive divisor. The builder never enforces the minimum `num_wires`/`num_routed_wires` invariants required by this gate family.

**Impact**

Any service that builds recursive or reduction-heavy circuits from user-provided configuration can be crashed by a single malformed config. The failure happens before the library can return a structured error, so the process aborts unless the caller wraps circuit building in panic recovery.

</details>
