### PR TITLE
V12 audit (8/10): medium lookup / interpolation / subgroup hardening

### DIFF
--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -24,3 +24,4 @@ finding	severity	class	commit	status	notes
 64678	Medium	runtime-dos-preconditions	2a71b8b37	fixed	Unchecked subgroup size panics
 64685	Medium	runtime-dos-preconditions	f9f3c9698	fixed	Zero generator hangs subgroup helpers
 64686	Medium	runtime-dos-preconditions	6b619d22a	fixed	Zero inputs panic batch inversion
+64687	Medium	untrusted-artifact-validation	5192053ce	fixed	Malformed verifier metadata triggers panic

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -27,3 +27,4 @@ finding	severity	class	commit	status	notes
 64687	Medium	untrusted-artifact-validation	5192053ce	fixed	Malformed verifier metadata triggers panic
 64690	Medium	untrusted-artifact-validation	c758e2bf8	fixed	Malformed domains panic in release
 64701	Medium	merkle-hash-binding	9ad1b7f85	fixed	Trailing-zero hash collisions
+64702	Medium	runtime-dos-preconditions	3725f4746	fixed	Zero-output request never terminates

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -25,3 +25,4 @@ finding	severity	class	commit	status	notes
 64685	Medium	runtime-dos-preconditions	f9f3c9698	fixed	Zero generator hangs subgroup helpers
 64686	Medium	runtime-dos-preconditions	6b619d22a	fixed	Zero inputs panic batch inversion
 64687	Medium	untrusted-artifact-validation	5192053ce	fixed	Malformed verifier metadata triggers panic
+64690	Medium	untrusted-artifact-validation	c758e2bf8	fixed	Malformed domains panic in release

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -26,3 +26,4 @@ finding	severity	class	commit	status	notes
 64686	Medium	runtime-dos-preconditions	6b619d22a	fixed	Zero inputs panic batch inversion
 64687	Medium	untrusted-artifact-validation	5192053ce	fixed	Malformed verifier metadata triggers panic
 64690	Medium	untrusted-artifact-validation	c758e2bf8	fixed	Malformed domains panic in release
+64701	Medium	merkle-hash-binding	9ad1b7f85	fixed	Trailing-zero hash collisions

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -20,3 +20,4 @@ finding	severity	class	commit	status	notes
 64656	Medium	untrusted-artifact-validation	5f2123e09	fixed	Forged lookup rows trigger panics
 64663	Medium	runtime-dos-preconditions	bc93cacce	test-only-covered	Invalid widths trigger reduction panic; root fixed by 06041ed09
 64671	Medium	untrusted-artifact-validation	492b97332	fixed	Zero-slot generator divide-by-zero
+64677	Medium	runtime-dos-preconditions	4d7c909a2	fixed	Malformed inputs trigger panics

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -23,3 +23,4 @@ finding	severity	class	commit	status	notes
 64677	Medium	runtime-dos-preconditions	4d7c909a2	fixed	Malformed inputs trigger panics
 64678	Medium	runtime-dos-preconditions	2a71b8b37	fixed	Unchecked subgroup size panics
 64685	Medium	runtime-dos-preconditions	f9f3c9698	fixed	Zero generator hangs subgroup helpers
+64686	Medium	runtime-dos-preconditions	6b619d22a	fixed	Zero inputs panic batch inversion

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -21,3 +21,4 @@ finding	severity	class	commit	status	notes
 64663	Medium	runtime-dos-preconditions	bc93cacce	test-only-covered	Invalid widths trigger reduction panic; root fixed by 06041ed09
 64671	Medium	untrusted-artifact-validation	492b97332	fixed	Zero-slot generator divide-by-zero
 64677	Medium	runtime-dos-preconditions	4d7c909a2	fixed	Malformed inputs trigger panics
+64678	Medium	runtime-dos-preconditions	2a71b8b37	fixed	Unchecked subgroup size panics

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -19,3 +19,4 @@ finding	severity	class	commit	status	notes
 64641	Medium	runtime-dos-preconditions	db4bcebfd	fixed	Insufficient routed wires panic
 64656	Medium	untrusted-artifact-validation	5f2123e09	fixed	Forged lookup rows trigger panics
 64663	Medium	runtime-dos-preconditions	bc93cacce	test-only-covered	Invalid widths trigger reduction panic; root fixed by 06041ed09
+64671	Medium	untrusted-artifact-validation	492b97332	fixed	Zero-slot generator divide-by-zero

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -22,3 +22,4 @@ finding	severity	class	commit	status	notes
 64671	Medium	untrusted-artifact-validation	492b97332	fixed	Zero-slot generator divide-by-zero
 64677	Medium	runtime-dos-preconditions	4d7c909a2	fixed	Malformed inputs trigger panics
 64678	Medium	runtime-dos-preconditions	2a71b8b37	fixed	Unchecked subgroup size panics
+64685	Medium	runtime-dos-preconditions	f9f3c9698	fixed	Zero generator hangs subgroup helpers

--- a/core/src/circuit_config.rs
+++ b/core/src/circuit_config.rs
@@ -287,6 +287,16 @@ impl CircuitConfig {
         Ok(())
     }
 
+    pub fn check_lookup_widths(&self) -> Result<(), &'static str> {
+        if self.num_routed_wires / 2 == 0 {
+            return Err("not enough routed wires for lookup gate");
+        }
+        if self.num_routed_wires / 3 == 0 {
+            return Err("not enough routed wires for lookup table gate");
+        }
+        Ok(())
+    }
+
     /// Validate that the circuit config has valid parameters. Panics on failure.
     ///
     /// Use this at circuit build time where invalid config is a programmer error.

--- a/core/src/hashing.rs
+++ b/core/src/hashing.rs
@@ -69,6 +69,10 @@ pub fn hash_n_to_m_no_pad<F: RichField, P: PlonkyPermutation<F>>(
     inputs: &[F],
     num_outputs: usize,
 ) -> Vec<F> {
+    if num_outputs == 0 {
+        return Vec::new();
+    }
+
     let mut perm = P::new(core::iter::repeat(F::ZERO));
 
     // Absorb all input chunks.
@@ -154,5 +158,14 @@ mod tests {
             hash_n_to_hash_len_delimited::<F, P>(&[x]),
             hash_n_to_hash_len_delimited::<F, P>(&[x, F::ZERO])
         );
+    }
+
+    #[test]
+    fn zero_output_hash_returns_empty() {
+        type F = GoldilocksField;
+        type P = <PoseidonHash as Hasher<F>>::Permutation;
+
+        assert!(hash_n_to_m_no_pad::<F, P>(&[F::ONE, F::TWO], 0).is_empty());
+        assert_eq!(hash_n_to_m_no_pad::<F, P>(&[F::ONE], 3).len(), 3);
     }
 }

--- a/core/src/hashing.rs
+++ b/core/src/hashing.rs
@@ -94,6 +94,18 @@ pub fn hash_n_to_hash_no_pad<F: RichField, P: PlonkyPermutation<F>>(inputs: &[F]
     HashOut::from_vec(hash_n_to_m_no_pad::<F, P>(inputs, NUM_HASH_OUT_ELTS))
 }
 
+/// Hash a variable-length message by prefixing its exact field-element length before using the
+/// fixed-length no-pad sponge. Prefer this over [`hash_n_to_hash_no_pad`] when message lengths are
+/// not already fixed by the protocol.
+pub fn hash_n_to_hash_len_delimited<F: RichField, P: PlonkyPermutation<F>>(
+    inputs: &[F],
+) -> HashOut<F> {
+    let mut encoded = Vec::with_capacity(inputs.len() + 1);
+    encoded.push(F::from_canonical_usize(inputs.len()));
+    encoded.extend_from_slice(inputs);
+    hash_n_to_hash_no_pad::<F, P>(&encoded)
+}
+
 /// Poseidon2 variable length padding (…||1||0* to RATE)
 pub fn hash_n_to_hash_no_pad_p2<F: RichField, P: PlonkyPermutation<F>>(inputs: &[F]) -> HashOut<F> {
     let rate = P::RATE;
@@ -119,4 +131,28 @@ pub fn hash_n_to_hash_no_pad_p2<F: RichField, P: PlonkyPermutation<F>>(inputs: &
 
     // Squeeze without an extra permute.
     HashOut::from_vec(perm.squeeze()[..NUM_HASH_OUT_ELTS].to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Hasher;
+    use crate::field::goldilocks_field::GoldilocksField;
+    use crate::poseidon::PoseidonHash;
+
+    #[test]
+    fn length_delimited_hash_distinguishes_trailing_zeros() {
+        type F = GoldilocksField;
+        type P = <PoseidonHash as Hasher<F>>::Permutation;
+
+        let x = F::from_canonical_u64(123);
+        assert_eq!(
+            hash_n_to_hash_no_pad::<F, P>(&[x]),
+            hash_n_to_hash_no_pad::<F, P>(&[x, F::ZERO])
+        );
+        assert_ne!(
+            hash_n_to_hash_len_delimited::<F, P>(&[x]),
+            hash_n_to_hash_len_delimited::<F, P>(&[x, F::ZERO])
+        );
+    }
 }

--- a/field/src/cosets.rs
+++ b/field/src/cosets.rs
@@ -1,15 +1,36 @@
 use alloc::vec::Vec;
 
+use anyhow::{ensure, Result};
 use num::bigint::BigUint;
+use num::Zero;
 
 use crate::types::Field;
 
 /// Finds a set of shifts that result in unique cosets for the multiplicative subgroup of size
 /// `2^subgroup_bits`.
 pub fn get_unique_coset_shifts<F: Field>(subgroup_size: usize, num_shifts: usize) -> Vec<F> {
+    try_get_unique_coset_shifts(subgroup_size, num_shifts).expect("invalid coset shift parameters")
+}
+
+pub fn try_get_unique_coset_shifts<F: Field>(
+    subgroup_size: usize,
+    num_shifts: usize,
+) -> Result<Vec<F>> {
+    ensure!(subgroup_size != 0, "subgroup size must be non-zero");
+    ensure!(
+        subgroup_size <= u32::MAX as usize,
+        "subgroup size exceeds supported range"
+    );
+
     // From Lagrange's theorem.
-    let num_cosets = (F::order() - 1u32) / (subgroup_size as u32);
-    assert!(
+    let group_order = F::order() - 1u32;
+    let subgroup_size = BigUint::from(subgroup_size);
+    ensure!(
+        (&group_order % &subgroup_size).is_zero(),
+        "subgroup size must divide the multiplicative group order"
+    );
+    let num_cosets = group_order / subgroup_size;
+    ensure!(
         BigUint::from(num_shifts) <= num_cosets,
         "The subgroup does not have enough distinct cosets"
     );
@@ -17,17 +38,17 @@ pub fn get_unique_coset_shifts<F: Field>(subgroup_size: usize, num_shifts: usize
     // Let g be a generator of the entire multiplicative group. Let n be the order of the subgroup.
     // The subgroup can be written as <g^(|F*| / n)>. We can use g^0, ..., g^(num_shifts - 1) as our
     // shifts, since g^i <g^(|F*| / n)> are distinct cosets provided i < |F*| / n, which we checked.
-    F::MULTIPLICATIVE_GROUP_GENERATOR
+    Ok(F::MULTIPLICATIVE_GROUP_GENERATOR
         .powers()
         .take(num_shifts)
-        .collect()
+        .collect::<Vec<_>>())
 }
 
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
 
-    use crate::cosets::get_unique_coset_shifts;
+    use crate::cosets::{get_unique_coset_shifts, try_get_unique_coset_shifts};
     use crate::goldilocks_field::GoldilocksField;
     use crate::types::Field;
 
@@ -50,5 +71,18 @@ mod tests {
                 "Duplicate element!"
             );
         }
+    }
+
+    #[test]
+    fn subgroup_size_validation() {
+        type F = GoldilocksField;
+        assert!(try_get_unique_coset_shifts::<F>(0, 1).is_err());
+        if usize::BITS > 32 {
+            assert!(try_get_unique_coset_shifts::<F>(1usize << 32, 1).is_err());
+        }
+        assert!(try_get_unique_coset_shifts::<F>(7, 1).is_err());
+
+        let valid = try_get_unique_coset_shifts::<F>(1 << 5, 4).unwrap();
+        assert_eq!(valid, get_unique_coset_shifts::<F>(1 << 5, 4));
     }
 }

--- a/field/src/interpolation.rs
+++ b/field/src/interpolation.rs
@@ -1,5 +1,6 @@
 use alloc::vec::Vec;
 
+use anyhow::{ensure, Result};
 use plonky2_util::log2_ceil;
 
 use crate::fft::ifft;
@@ -11,68 +12,117 @@ use crate::types::Field;
 /// Note that the implementation assumes that `F` is two-adic, in particular that
 /// `2^{F::TWO_ADICITY} >= points.len()`. This leads to a simple FFT-based implementation.
 pub fn interpolant<F: Field>(points: &[(F, F)]) -> PolynomialCoeffs<F> {
+    try_interpolant(points).expect("invalid interpolation points")
+}
+
+pub fn try_interpolant<F: Field>(points: &[(F, F)]) -> Result<PolynomialCoeffs<F>> {
+    validate_interpolation_points(points)?;
     let n = points.len();
     let n_log = log2_ceil(n);
 
     let subgroup = F::two_adic_subgroup(n_log);
-    let barycentric_weights = barycentric_weights(points);
+    let barycentric_weights = try_barycentric_weights(points)?;
     let subgroup_evals = subgroup
         .into_iter()
-        .map(|x| interpolate(points, x, &barycentric_weights))
-        .collect();
+        .map(|x| try_interpolate(points, x, &barycentric_weights))
+        .collect::<Result<Vec<_>>>()?;
 
     let mut coeffs = ifft(PolynomialValues::new(subgroup_evals));
     coeffs.trim();
-    coeffs
+    Ok(coeffs)
 }
 
 /// Interpolate the polynomial defined by an arbitrary set of (point, value) pairs at the given
 /// point `x`.
 pub fn interpolate<F: Field>(points: &[(F, F)], x: F, barycentric_weights: &[F]) -> F {
+    try_interpolate(points, x, barycentric_weights).expect("invalid interpolation inputs")
+}
+
+pub fn try_interpolate<F: Field>(points: &[(F, F)], x: F, barycentric_weights: &[F]) -> Result<F> {
+    validate_interpolation_points(points)?;
+    ensure!(
+        barycentric_weights.len() == points.len(),
+        "barycentric weight count must match point count"
+    );
+
     // If x is in the list of points, the Lagrange formula would divide by zero.
     for &(x_i, y_i) in points {
         if x_i == x {
-            return y_i;
+            return Ok(y_i);
         }
     }
 
     let l_x: F = points.iter().map(|&(x_i, _y_i)| x - x_i).product();
 
-    let sum = (0..points.len())
-        .map(|i| {
-            let x_i = points[i].0;
-            let y_i = points[i].1;
-            let w_i = barycentric_weights[i];
-            w_i / (x - x_i) * y_i
-        })
-        .sum();
+    let mut sum = F::ZERO;
+    for i in 0..points.len() {
+        let x_i = points[i].0;
+        let y_i = points[i].1;
+        let w_i = barycentric_weights[i];
+        let denominator = x - x_i;
+        let denominator_inv = denominator
+            .try_inverse()
+            .ok_or_else(|| anyhow::anyhow!("interpolation denominator is zero"))?;
+        sum += w_i * denominator_inv * y_i;
+    }
 
-    l_x * sum
+    Ok(l_x * sum)
 }
 
 pub fn barycentric_weights<F: Field>(points: &[(F, F)]) -> Vec<F> {
+    try_barycentric_weights(points).expect("invalid interpolation points")
+}
+
+pub fn try_barycentric_weights<F: Field>(points: &[(F, F)]) -> Result<Vec<F>> {
+    validate_interpolation_points(points)?;
     let n = points.len();
-    F::batch_multiplicative_inverse(
-        &(0..n)
-            .map(|i| {
-                (0..n)
-                    .filter(|&j| j != i)
-                    .map(|j| points[i].0 - points[j].0)
-                    .product::<F>()
-            })
-            .collect::<Vec<_>>(),
-    )
+    let mut weights = Vec::with_capacity(n);
+    for i in 0..n {
+        let denominator = (0..n)
+            .filter(|&j| j != i)
+            .map(|j| points[i].0 - points[j].0)
+            .product::<F>();
+        let inverse = denominator
+            .try_inverse()
+            .ok_or_else(|| anyhow::anyhow!("barycentric denominator is zero"))?;
+        weights.push(inverse);
+    }
+    Ok(weights)
 }
 
 /// Interpolate the linear polynomial passing through `points` on `x`.
 pub fn interpolate2<F: Field>(points: [(F, F); 2], x: F) -> F {
+    try_interpolate2(points, x).expect("interpolate2 requires distinct x-coordinates")
+}
+
+pub fn try_interpolate2<F: Field>(points: [(F, F); 2], x: F) -> Result<F> {
     // a0 -> a1
     // b0 -> b1
     // x  -> a1 + (x-a0)*(b1-a1)/(b0-a0)
     let (a0, a1) = points[0];
     let (b0, b1) = points[1];
-    assert_ne!(a0, b0);
-    a1 + (x - a0) * (b1 - a1) / (b0 - a0)
+    let denominator_inv = (b0 - a0)
+        .try_inverse()
+        .ok_or_else(|| anyhow::anyhow!("interpolate2 requires distinct x-coordinates"))?;
+    Ok(a1 + (x - a0) * (b1 - a1) * denominator_inv)
+}
+
+fn validate_interpolation_points<F: Field>(points: &[(F, F)]) -> Result<()> {
+    ensure!(!points.is_empty(), "interpolation point set is empty");
+    let n_log = log2_ceil(points.len());
+    ensure!(
+        n_log <= F::TWO_ADICITY,
+        "interpolation point set exceeds field two-adicity"
+    );
+    for i in 0..points.len() {
+        for j in i + 1..points.len() {
+            ensure!(
+                points[i].0 != points[j].0,
+                "interpolation x-coordinates must be distinct"
+            );
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -88,7 +138,7 @@ mod tests {
     fn interpolant_random() {
         type F = GoldilocksField;
 
-        for deg in 0..10 {
+        for deg in 1..10 {
             let domain = F::rand_vec(deg);
             let coeffs = F::rand_vec(deg);
             let coeffs = PolynomialCoeffs { coeffs };
@@ -144,5 +194,29 @@ mod tests {
 
         assert_eq!(ev0, ev1);
         assert_eq!(ev0, ev2);
+    }
+
+    #[test]
+    fn malformed_interpolation_inputs_return_err() {
+        type F = GoldilocksField;
+        let duplicate = vec![(F::ONE, F::TWO), (F::ONE, F::ZERO)];
+        assert!(try_barycentric_weights(&duplicate).is_err());
+        assert!(try_interpolant(&duplicate).is_err());
+        assert!(try_interpolate2([(F::ONE, F::ZERO), (F::ONE, F::TWO)], F::ZERO).is_err());
+
+        let empty: Vec<(F, F)> = Vec::new();
+        assert!(try_barycentric_weights(&empty).is_err());
+        assert!(try_interpolant(&empty).is_err());
+
+        let valid = vec![
+            (F::ZERO, F::from_canonical_u64(3)),
+            (F::ONE, F::from_canonical_u64(5)),
+        ];
+        let weights = try_barycentric_weights(&valid).unwrap();
+        assert_eq!(
+            try_interpolate(&valid, F::TWO, &weights).unwrap(),
+            interpolate(&valid, F::TWO, &weights)
+        );
+        assert_eq!(try_interpolant(&valid).unwrap(), interpolant(&valid));
     }
 }

--- a/field/src/polynomial/mod.rs
+++ b/field/src/polynomial/mod.rs
@@ -26,9 +26,29 @@ pub struct PolynomialValues<F: Field> {
 
 impl<F: Field> PolynomialValues<F> {
     pub fn new(values: Vec<F>) -> Self {
-        // Check that a subgroup exists of this size, which should be a power of two.
-        debug_assert!(log2_strict(values.len()) <= F::TWO_ADICITY);
-        PolynomialValues { values }
+        Self::try_new(values).expect("invalid polynomial evaluation domain")
+    }
+
+    pub fn try_new(values: Vec<F>) -> Result<Self> {
+        Self::check_domain_len(values.len())?;
+        Ok(PolynomialValues { values })
+    }
+
+    pub fn check_valid(&self) -> Result<()> {
+        Self::check_domain_len(self.values.len())
+    }
+
+    fn check_domain_len(len: usize) -> Result<()> {
+        ensure!(len > 0, "polynomial evaluation domain is empty");
+        ensure!(
+            len.is_power_of_two(),
+            "polynomial evaluation domain length is not a power of two"
+        );
+        ensure!(
+            log2_strict(len) <= F::TWO_ADICITY,
+            "polynomial evaluation domain exceeds field two-adicity"
+        );
+        Ok(())
     }
 
     pub fn constant(value: F, len: usize) -> Self {
@@ -472,6 +492,20 @@ mod tests {
                 coeffs: vec![F::ONE, F::TWO]
             }
         );
+    }
+
+    #[test]
+    fn polynomial_values_reject_malformed_domains() {
+        type F = GoldilocksField;
+
+        assert!(PolynomialValues::<F>::try_new(vec![]).is_err());
+        assert!(PolynomialValues::<F>::try_new(vec![F::ZERO; 3]).is_err());
+        assert!(PolynomialValues::<F>::try_new(vec![F::ZERO; 4]).is_ok());
+
+        let malformed = PolynomialValues::<F> {
+            values: vec![F::ZERO; 3],
+        };
+        assert!(malformed.check_valid().is_err());
     }
 
     #[test]

--- a/field/src/types.rs
+++ b/field/src/types.rs
@@ -5,6 +5,7 @@ use core::hash::Hash;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
+use anyhow::{ensure, Result};
 use num::bigint::BigUint;
 use num::{Integer, One, ToPrimitive, Zero};
 use plonky2_util::bits_u64;
@@ -295,18 +296,35 @@ pub trait Field:
     }
 
     fn cyclic_subgroup_unknown_order(generator: Self) -> Vec<Self> {
-        let mut subgroup = Vec::new();
-        for power in generator.powers() {
-            if power.is_one() && !subgroup.is_empty() {
-                break;
-            }
-            subgroup.push(power);
-        }
-        subgroup
+        Self::try_cyclic_subgroup_unknown_order(generator)
+            .expect("invalid multiplicative subgroup generator")
+    }
+
+    fn try_cyclic_subgroup_unknown_order(generator: Self) -> Result<Vec<Self>> {
+        let order = Self::try_generator_order(generator)?;
+        Ok(Self::cyclic_subgroup_known_order(generator, order))
     }
 
     fn generator_order(generator: Self) -> usize {
-        generator.powers().skip(1).position(|y| y.is_one()).unwrap() + 1
+        Self::try_generator_order(generator).expect("invalid multiplicative subgroup generator")
+    }
+
+    fn try_generator_order(generator: Self) -> Result<usize> {
+        ensure!(
+            !generator.is_zero(),
+            "multiplicative subgroup generator must be nonzero"
+        );
+        let group_order = (Self::order() - 1u32)
+            .to_usize()
+            .ok_or_else(|| anyhow::anyhow!("multiplicative group order exceeds usize"))?;
+        for (i, power) in generator.powers().skip(1).take(group_order).enumerate() {
+            if power.is_one() {
+                return Ok(i + 1);
+            }
+        }
+        Err(anyhow::anyhow!(
+            "generator did not return to one within the multiplicative group order"
+        ))
     }
 
     /// Computes a coset of a multiplicative subgroup whose order is known in advance.
@@ -648,5 +666,22 @@ mod tests {
                 assert_eq!(iter.next(), Some(expect_next));
             }
         }
+    }
+
+    #[test]
+    fn generator_order_rejects_zero() {
+        type F = GoldilocksField;
+
+        assert!(F::try_generator_order(F::ZERO).is_err());
+        assert!(F::try_cyclic_subgroup_unknown_order(F::ZERO).is_err());
+
+        let order = F::try_generator_order(F::primitive_root_of_unity(5)).unwrap();
+        assert_eq!(order, 1 << 5);
+        assert_eq!(
+            F::try_cyclic_subgroup_unknown_order(F::primitive_root_of_unity(3))
+                .unwrap()
+                .len(),
+            1 << 3
+        );
     }
 }

--- a/field/src/types.rs
+++ b/field/src/types.rs
@@ -144,6 +144,18 @@ pub trait Field:
     }
 
     fn batch_multiplicative_inverse(x: &[Self]) -> Vec<Self> {
+        Self::try_batch_multiplicative_inverse(x).expect("batch inverse input contained zero")
+    }
+
+    fn try_batch_multiplicative_inverse(x: &[Self]) -> Result<Vec<Self>> {
+        ensure!(
+            x.iter().all(|x_i| !x_i.is_zero()),
+            "batch inverse input contained zero"
+        );
+        Ok(Self::batch_multiplicative_inverse_nonzero(x))
+    }
+
+    fn batch_multiplicative_inverse_nonzero(x: &[Self]) -> Vec<Self> {
         // This is Montgomery's trick. At a high level, we invert the product of the given field
         // elements, then derive the individual inverses from that via multiplication.
 
@@ -683,5 +695,23 @@ mod tests {
                 .len(),
             1 << 3
         );
+    }
+
+    #[test]
+    fn batch_multiplicative_inverse_rejects_zero() {
+        type F = GoldilocksField;
+
+        assert!(F::try_batch_multiplicative_inverse(&[F::ONE, F::ZERO, F::TWO]).is_err());
+
+        let xs = [
+            F::from_canonical_u64(3),
+            F::from_canonical_u64(5),
+            F::from_canonical_u64(7),
+        ];
+        let invs = F::try_batch_multiplicative_inverse(&xs).unwrap();
+        assert_eq!(invs, F::batch_multiplicative_inverse(&xs));
+        for (&x, &x_inv) in xs.iter().zip(&invs) {
+            assert_eq!(x * x_inv, F::ONE);
+        }
     }
 }

--- a/field/src/zero_poly_coset.rs
+++ b/field/src/zero_poly_coset.rs
@@ -54,7 +54,7 @@ impl<F: Field> ZeroPolyOnCoset<F> {
             .into_iter()
             .map(|x| g_pow_n * x - F::ONE)
             .collect::<Vec<_>>();
-        let inverses = F::batch_multiplicative_inverse(&evals);
+        let inverses = F::try_batch_multiplicative_inverse(&evals)?;
         Ok(Self {
             n: F::from_canonical_usize(n),
             rate,

--- a/plonky2/src/batch_fri/oracle.rs
+++ b/plonky2/src/batch_fri/oracle.rs
@@ -209,20 +209,44 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         timing: &mut TimingTree,
         fft_root_table: &[Option<&FftRootTable<F>>],
     ) -> Self {
-        let coeffs = timed!(
-            timing,
-            "IFFT",
-            values.into_par_iter().map(|v| v.ifft()).collect::<Vec<_>>()
-        );
-
-        Self::from_coeffs(
-            coeffs,
+        Self::try_from_values(
+            values,
             rate_bits,
             blinding,
             cap_height,
             timing,
             fft_root_table,
         )
+        .expect("invalid polynomial values")
+    }
+
+    /// Fallible variant of [`Self::from_values`] for values supplied across a trust boundary.
+    pub fn try_from_values(
+        values: Vec<PolynomialValues<F>>,
+        rate_bits: usize,
+        blinding: bool,
+        cap_height: usize,
+        timing: &mut TimingTree,
+        fft_root_table: &[Option<&FftRootTable<F>>],
+    ) -> Result<Self> {
+        ensure!(!values.is_empty(), "polynomial value batch is empty");
+        for values in &values {
+            values.check_valid()?;
+        }
+        let coeffs = timed!(
+            timing,
+            "IFFT",
+            values.into_par_iter().map(|v| v.ifft()).collect::<Vec<_>>()
+        );
+
+        Ok(Self::from_coeffs(
+            coeffs,
+            rate_bits,
+            blinding,
+            cap_height,
+            timing,
+            fft_root_table,
+        ))
     }
 
     /// Creates a list polynomial commitment for the polynomials `polynomials`.

--- a/plonky2/src/batch_fri/oracle.rs
+++ b/plonky2/src/batch_fri/oracle.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "std"))]
-use alloc::{format, vec::Vec};
+use alloc::{format, vec, vec::Vec};
 
 use anyhow::{ensure, Result};
 use itertools::Itertools;

--- a/plonky2/src/batch_fri/verifier.rs
+++ b/plonky2/src/batch_fri/verifier.rs
@@ -10,12 +10,11 @@ use crate::fri::proof::{
     eval_final_polys_at_point, FriChallenges, FriInitialTreeProof, FriProof, FriQueryRound,
 };
 use crate::fri::structure::{FriBatchInfo, FriInstanceInfo, FriOpenings};
-use crate::fri::validate_batch_fri_auxiliary_shape;
 use crate::fri::verifier::{
     compute_evaluation, eval_opening_expression, fri_verify_proof_of_work,
     PrecomputedReducedOpenings,
 };
-use crate::fri::FriParams;
+use crate::fri::{validate_batch_fri_auxiliary_shape, FriParams};
 use crate::hash::hash_types::RichField;
 use crate::hash::merkle_proofs::{verify_batch_merkle_proof_to_cap, verify_merkle_proof_to_cap};
 use crate::hash::merkle_tree::MerkleCap;

--- a/plonky2/src/fri/mod.rs
+++ b/plonky2/src/fri/mod.rs
@@ -23,15 +23,14 @@ pub mod validate_shape;
 pub mod verifier;
 pub mod witness_util;
 
-pub use validate_shape::{
-    validate_batch_fri_auxiliary_shape, validate_batch_fri_proof_shape,
-    validate_fri_auxiliary_shape,
-};
-
 // Re-export FRI types from core
 pub use qp_plonky2_core::{
     FriBatchMaskingParams, FriChallenger, FriConfig, FriConfigObserve, FriFinalPolyLayout,
     FriParams, FriParamsObserve, FriReductionStrategy,
+};
+pub use validate_shape::{
+    validate_batch_fri_auxiliary_shape, validate_batch_fri_proof_shape,
+    validate_fri_auxiliary_shape,
 };
 
 /// Trait for observing FRI configuration in a RecursiveChallenger (circuit target version).

--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -1,6 +1,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::{format, vec, vec::Vec};
 
+use anyhow::{ensure, Result};
 use hashbrown::HashMap;
 use itertools::Itertools;
 use plonky2_field::types::Field;
@@ -333,20 +334,44 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         timing: &mut TimingTree,
         fft_root_table: Option<&FftRootTable<F>>,
     ) -> Self {
-        let coeffs = timed!(
-            timing,
-            "IFFT",
-            values.into_par_iter().map(|v| v.ifft()).collect::<Vec<_>>()
-        );
-
-        Self::from_coeffs(
-            coeffs,
+        Self::try_from_values(
+            values,
             rate_bits,
             blinding,
             cap_height,
             timing,
             fft_root_table,
         )
+        .expect("invalid polynomial values")
+    }
+
+    /// Fallible variant of [`Self::from_values`] for values supplied across a trust boundary.
+    pub fn try_from_values(
+        values: Vec<PolynomialValues<F>>,
+        rate_bits: usize,
+        blinding: bool,
+        cap_height: usize,
+        timing: &mut TimingTree,
+        fft_root_table: Option<&FftRootTable<F>>,
+    ) -> Result<Self> {
+        ensure!(!values.is_empty(), "polynomial value batch is empty");
+        for values in &values {
+            values.check_valid()?;
+        }
+        let coeffs = timed!(
+            timing,
+            "IFFT",
+            values.into_par_iter().map(|v| v.ifft()).collect::<Vec<_>>()
+        );
+
+        Ok(Self::from_coeffs(
+            coeffs,
+            rate_bits,
+            blinding,
+            cap_height,
+            timing,
+            fft_root_table,
+        ))
     }
 
     /// Creates a list polynomial commitment for the polynomials `polynomials`.

--- a/plonky2/src/gadgets/lookup.rs
+++ b/plonky2/src/gadgets/lookup.rs
@@ -78,6 +78,11 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     /// We call this function at the end of circuit building right before the PI gate to add all `LookupTableGate` and `LookupGate`.
     /// It also updates `self.lookup_rows` accordingly.
     pub fn add_all_lookups(&mut self) {
+        if self.num_luts() != 0 {
+            self.config
+                .check_lookup_widths()
+                .expect("Invalid lookup circuit config");
+        }
         for lut_index in 0..self.num_luts() {
             assert!(
                 !self.get_lut_lookups(lut_index).is_empty(),

--- a/plonky2/src/gates/coset_interpolation.rs
+++ b/plonky2/src/gates/coset_interpolation.rs
@@ -8,11 +8,11 @@ use alloc::{
 use core::marker::PhantomData;
 use core::ops::Range;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, ensure, Result};
 
 use crate::field::extension::algebra::ExtensionAlgebra;
 use crate::field::extension::{Extendable, FieldExtension, OEF};
-use crate::field::interpolation::barycentric_weights;
+use crate::field::interpolation::try_barycentric_weights;
 use crate::field::types::Field;
 use crate::gates::gate::Gate;
 use crate::gates::util::StridedConstraintConsumer;
@@ -25,7 +25,7 @@ use crate::iop::witness::{PartitionWitness, Witness, WitnessWrite};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
-use crate::util::serialization::{Buffer, IoResult, Read, Write};
+use crate::util::serialization::{Buffer, IoError, IoResult, Read, Write};
 
 /// One of the instantiations of `InterpolationGate`: allows constraints of variable
 /// degree, up to `1<<subgroup_bits`.
@@ -65,13 +65,25 @@ pub struct CosetInterpolationGate<F: RichField + Extendable<D>, const D: usize> 
 
 impl<F: RichField + Extendable<D>, const D: usize> CosetInterpolationGate<F, D> {
     pub fn new(subgroup_bits: usize) -> Self {
-        Self::with_max_degree(subgroup_bits, 1 << subgroup_bits)
+        let max_degree = checked_num_points::<F>(subgroup_bits)
+            .expect("invalid coset interpolation subgroup bits");
+        Self::with_max_degree(subgroup_bits, max_degree)
     }
 
     pub(crate) fn with_max_degree(subgroup_bits: usize, max_degree: usize) -> Self {
-        assert!(max_degree > 1, "need at least quadratic constraints");
+        Self::try_with_max_degree(subgroup_bits, max_degree)
+            .expect("invalid coset interpolation gate parameters")
+    }
 
-        let n_points = 1 << subgroup_bits;
+    pub(crate) fn try_with_max_degree(subgroup_bits: usize, max_degree: usize) -> Result<Self> {
+        ensure!(max_degree > 1, "need at least quadratic constraints");
+        ensure!(
+            subgroup_bits <= F::TWO_ADICITY,
+            "subgroup bits exceed field two-adicity"
+        );
+
+        let n_points = checked_num_points::<F>(subgroup_bits)?;
+        ensure!(n_points >= 2, "need at least two interpolation points");
 
         // Number of intermediate values required to compute interpolation with degree bound
         let n_intermediates = (n_points - 2) / (max_degree - 1);
@@ -80,19 +92,34 @@ impl<F: RichField + Extendable<D>, const D: usize> CosetInterpolationGate<F, D> 
         // Minimizing the degree this way allows the gate to be in a larger selector group
         let degree = (n_points - 2) / (n_intermediates + 1) + 2;
 
-        let barycentric_weights = barycentric_weights(
+        let barycentric_weights = try_barycentric_weights(
             &F::two_adic_subgroup(subgroup_bits)
                 .into_iter()
                 .map(|x| (x, F::ZERO))
                 .collect::<Vec<_>>(),
-        );
+        )?;
 
-        Self {
+        Ok(Self {
             subgroup_bits,
             degree,
             barycentric_weights,
             _phantom: PhantomData,
-        }
+        })
+    }
+
+    fn check_valid(&self) -> Result<()> {
+        let n_points = checked_num_points::<F>(self.subgroup_bits)?;
+        ensure!(n_points >= 2, "need at least two interpolation points");
+        ensure!(self.degree > 1, "need at least quadratic constraints");
+        ensure!(
+            self.degree <= n_points,
+            "interpolation gate degree exceeds point count"
+        );
+        ensure!(
+            self.barycentric_weights.len() == n_points,
+            "barycentric weight count must match interpolation point count"
+        );
+        Ok(())
     }
 
     const fn num_points(&self) -> usize {
@@ -194,12 +221,14 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for CosetInterpola
         let degree = src.read_usize()?;
         let length = src.read_usize()?;
         let barycentric_weights: Vec<F> = src.read_field_vec(length)?;
-        Ok(Self {
+        let gate = Self {
             subgroup_bits,
             degree,
             barycentric_weights,
             _phantom: PhantomData,
-        })
+        };
+        gate.check_valid().map_err(|_| IoError)?;
+        Ok(gate)
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {
@@ -463,6 +492,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D>
         witness: &PartitionWitness<F>,
         out_buffer: &mut GeneratedValues<F>,
     ) -> Result<()> {
+        self.gate.check_valid()?;
         let local_wire = |column| Wire {
             row: self.row,
             column,
@@ -539,6 +569,16 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D>
         let gate = CosetInterpolationGate::deserialize(src, _common_data)?;
         Ok(Self::new(row, gate))
     }
+}
+
+fn checked_num_points<F: Field>(subgroup_bits: usize) -> Result<usize> {
+    ensure!(
+        subgroup_bits <= F::TWO_ADICITY,
+        "subgroup bits exceed field two-adicity"
+    );
+    1usize
+        .checked_shl(subgroup_bits.try_into().unwrap_or(usize::BITS))
+        .ok_or_else(|| anyhow!("interpolation subgroup size overflow"))
 }
 
 /// Interpolate the polynomial defined by its values on an arbitrary domain at the given point `x`.
@@ -670,6 +710,7 @@ mod tests {
 
     use super::*;
     use crate::field::goldilocks_field::GoldilocksField;
+    use crate::field::interpolation::barycentric_weights;
     use crate::field::types::Sample;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::hash::hash_types::HashOut;

--- a/plonky2/src/gates/lookup.rs
+++ b/plonky2/src/gates/lookup.rs
@@ -95,7 +95,8 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for LookupGate {
         let lut_index = src.read_usize()?;
         let mut lut_hash = [0u8; 32];
         src.read_exact(&mut lut_hash)?;
-        if num_slots != Self::num_slots(&common_data.config) {
+        let expected_num_slots = Self::num_slots(&common_data.config);
+        if expected_num_slots == 0 || num_slots != expected_num_slots {
             return Err(crate::util::serialization::IoError);
         }
         let lut = common_data

--- a/plonky2/src/gates/lookup_table.rs
+++ b/plonky2/src/gates/lookup_table.rs
@@ -9,7 +9,7 @@ use alloc::{
 #[cfg(feature = "std")]
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{ensure, Result};
 use itertools::Itertools;
 use keccak_hash::keccak;
 
@@ -110,7 +110,8 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for LookupTableGat
         let lut_index = src.read_usize()?;
         let mut lut_hash = [0u8; 32];
         src.read_exact(&mut lut_hash)?;
-        if num_slots != Self::num_slots(&common_data.config) {
+        let expected_num_slots = Self::num_slots(&common_data.config);
+        if expected_num_slots == 0 || num_slots != expected_num_slots {
             return Err(crate::util::serialization::IoError);
         }
         let lut = common_data
@@ -219,8 +220,20 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Loo
         _witness: &PartitionWitness<F>,
         out_buffer: &mut GeneratedValues<F>,
     ) -> Result<()> {
-        let first_row = self.last_lut_row + self.lut.len().div_ceil(self.num_slots) - 1;
-        let slot = (first_row - self.row) * self.num_slots + self.slot_nb;
+        ensure!(self.num_slots != 0, "LookupTableGenerator has zero slots");
+        let lut_rows = self.lut.len().div_ceil(self.num_slots);
+        let first_row = self
+            .last_lut_row
+            .checked_add(lut_rows)
+            .and_then(|row| row.checked_sub(1))
+            .ok_or_else(|| anyhow::anyhow!("LookupTableGenerator row range overflow"))?;
+        let row_offset = first_row
+            .checked_sub(self.row)
+            .ok_or_else(|| anyhow::anyhow!("LookupTableGenerator row outside table range"))?;
+        let slot = row_offset
+            .checked_mul(self.num_slots)
+            .and_then(|offset| offset.checked_add(self.slot_nb))
+            .ok_or_else(|| anyhow::anyhow!("LookupTableGenerator slot overflow"))?;
 
         let slot_input_target =
             Target::wire(self.row, LookupTableGate::wire_ith_looked_inp(self.slot_nb));
@@ -260,10 +273,22 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Loo
         let num_slots = src.read_usize()?;
         let last_lut_row = src.read_usize()?;
         let lut_index = src.read_usize()?;
+        let expected_num_slots = LookupTableGate::num_slots(&common_data.config);
+        if expected_num_slots == 0 || num_slots != expected_num_slots || slot_nb >= num_slots {
+            return Err(crate::util::serialization::IoError);
+        }
+        let lut = common_data
+            .luts
+            .get(lut_index)
+            .ok_or(crate::util::serialization::IoError)?
+            .clone();
+        if lut.is_empty() {
+            return Err(crate::util::serialization::IoError);
+        }
 
         Ok(Self {
             row,
-            lut: common_data.luts[lut_index].clone(),
+            lut,
             slot_nb,
             num_slots,
             last_lut_row,

--- a/plonky2/src/gates/reducing.rs
+++ b/plonky2/src/gates/reducing.rs
@@ -8,6 +8,7 @@ use alloc::{
 use core::ops::Range;
 
 use anyhow::Result;
+use qp_plonky2_core::circuit_config::reducing_base_capacity;
 
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::gates::gate::Gate;
@@ -21,7 +22,6 @@ use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::{Buffer, IoResult, Read, Write};
-use qp_plonky2_core::circuit_config::reducing_base_capacity;
 
 /// Computes `sum alpha^i c_i` for a vector `c_i` of `num_coeffs` elements of the base field.
 #[derive(Debug, Default, Clone)]

--- a/plonky2/src/gates/reducing_extension.rs
+++ b/plonky2/src/gates/reducing_extension.rs
@@ -8,6 +8,7 @@ use alloc::{
 use core::ops::Range;
 
 use anyhow::Result;
+use qp_plonky2_core::circuit_config::reducing_extension_capacity;
 
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::gates::gate::Gate;
@@ -21,7 +22,6 @@ use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::{Buffer, IoResult, Read, Write};
-use qp_plonky2_core::circuit_config::reducing_extension_capacity;
 
 /// Computes `sum alpha^i c_i` for a vector `c_i` of `num_coeffs` elements of the extension field.
 #[derive(Debug, Clone, Default)]

--- a/plonky2/src/gates/selectors.rs
+++ b/plonky2/src/gates/selectors.rs
@@ -7,7 +7,6 @@
 use alloc::{vec, vec::Vec};
 
 use hashbrown::HashMap;
-
 // Re-export selector types from core
 pub use qp_plonky2_core::selectors::{LookupSelectors, SelectorsInfo, UNUSED_SELECTOR};
 

--- a/plonky2/src/hash/hashing.rs
+++ b/plonky2/src/hash/hashing.rs
@@ -7,8 +7,8 @@ use alloc::vec::Vec;
 
 // Re-export core hashing types and functions
 pub use qp_plonky2_core::hashing::{
-    compress, hash_n_to_hash_no_pad, hash_n_to_hash_no_pad_p2, hash_n_to_m_no_pad,
-    PlonkyPermutation,
+    compress, hash_n_to_hash_len_delimited, hash_n_to_hash_no_pad, hash_n_to_hash_no_pad_p2,
+    hash_n_to_m_no_pad, PlonkyPermutation,
 };
 
 use crate::field::extension::Extendable;

--- a/plonky2/src/hash/hashing.rs
+++ b/plonky2/src/hash/hashing.rs
@@ -31,6 +31,10 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         inputs: Vec<Target>,
         num_outputs: usize,
     ) -> Vec<Target> {
+        if num_outputs == 0 {
+            return Vec::new();
+        }
+
         let zero = self.zero();
         let mut state = H::AlgebraicPermutation::new(core::iter::repeat(zero));
 

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -1,7 +1,7 @@
 //! Logic for building plonky2 circuits.
 
 #[cfg(not(feature = "std"))]
-use alloc::{collections::BTreeMap, sync::Arc, vec, vec::Vec};
+use alloc::{collections::BTreeMap, string::String, sync::Arc, vec, vec::Vec};
 use core::cmp::max;
 #[cfg(feature = "std")]
 use std::{collections::BTreeMap, sync::Arc};

--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -622,6 +622,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CommonCircuitData<F, D> {
             .fri_config
             .required_proof_of_work_leading_zeros::<F>()
             .map_err(|_| "invalid FRI proof-of-work bits")?;
+        self.check_field_degree_bounds()?;
 
         // Quotient degree must fit within FRI rate.
         let quotient_degree_bits = log2_ceil(self.quotient_degree_factor);
@@ -644,6 +645,45 @@ impl<F: RichField + Extendable<D>, const D: usize> CommonCircuitData<F, D> {
         }
 
         check_gate_id_collisions(&self.gates)?;
+
+        Ok(())
+    }
+
+    fn check_field_degree_bounds(&self) -> Result<(), &'static str> {
+        if self.trace_degree_bits > F::TWO_ADICITY {
+            return Err("trace_degree_bits exceeds field two-adicity");
+        }
+        if self.public_initial_degree_bits > F::TWO_ADICITY {
+            return Err("public_initial_degree_bits exceeds field two-adicity");
+        }
+        if self.fri_params.degree_bits > F::TWO_ADICITY {
+            return Err("FRI degree_bits exceeds field two-adicity");
+        }
+
+        let trace_lde_bits = self
+            .trace_degree_bits
+            .checked_add(self.config.fri_config.rate_bits)
+            .ok_or("trace LDE degree overflow")?;
+        if trace_lde_bits > F::TWO_ADICITY {
+            return Err("trace LDE degree exceeds field two-adicity");
+        }
+
+        let public_lde_bits = self
+            .public_initial_degree_bits
+            .checked_add(self.config.fri_config.rate_bits)
+            .ok_or("public initial LDE degree overflow")?;
+        if public_lde_bits > F::TWO_ADICITY {
+            return Err("public initial LDE degree exceeds field two-adicity");
+        }
+
+        let fri_lde_bits = self
+            .fri_params
+            .degree_bits
+            .checked_add(self.fri_params.config.rate_bits)
+            .ok_or("FRI LDE degree overflow")?;
+        if fri_lde_bits > F::TWO_ADICITY {
+            return Err("FRI LDE degree exceeds field two-adicity");
+        }
 
         Ok(())
     }

--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -612,6 +612,9 @@ impl<F: RichField + Extendable<D>, const D: usize> CommonCircuitData<F, D> {
         self.config.check_valid()?;
         self.config.check_reducing_widths::<D>()?;
         self.config.check_extension_gate_widths::<D>()?;
+        if !self.luts.is_empty() || self.num_lookup_polys != 0 || self.num_lookup_selectors != 0 {
+            self.config.check_lookup_widths()?;
+        }
         self.fri_params
             .check_valid()
             .map_err(|_| "invalid FRI params")?;

--- a/plonky2/src/plonk/config.rs
+++ b/plonky2/src/plonk/config.rs
@@ -7,6 +7,8 @@
 //! mixing Poseidon internally and truncated Keccak externally.
 
 // Re-export core config types - these are the canonical definitions
+use alloc::vec::Vec;
+
 pub use qp_plonky2_core::config::{
     merkle_node_hash_input, GenericConfig, GenericHashOut, Hasher, KeccakGoldilocksConfig,
     PoseidonGoldilocksConfig, MERKLE_LEAF_DOMAIN_TAG, MERKLE_NODE_DOMAIN_TAG,

--- a/plonky2/src/plonk/config.rs
+++ b/plonky2/src/plonk/config.rs
@@ -7,6 +7,7 @@
 //! mixing Poseidon internally and truncated Keccak externally.
 
 // Re-export core config types - these are the canonical definitions
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 pub use qp_plonky2_core::config::{

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -4,6 +4,7 @@ use hashbrown::HashMap;
 use plonky2::batch_fri::oracle::BatchFriOracle;
 use plonky2::batch_fri::prover::batch_fri_proof;
 use plonky2::batch_fri::verifier::verify_batch_fri_proof;
+use plonky2::field::cosets::{get_unique_coset_shifts, try_get_unique_coset_shifts};
 use plonky2::field::interpolation::{try_barycentric_weights, try_interpolant, try_interpolate2};
 use plonky2::field::packable::Packable;
 use plonky2::field::packed::PackedField;
@@ -463,6 +464,18 @@ fn zero_poly_on_coset_valid_domain_works() {
     let eval = z_h.eval(0);
     let eval_inverse = z_h.eval_inverse(0);
     assert_eq!(eval * eval_inverse, F::ONE);
+}
+
+#[test]
+fn subgroup_size_validation_rejects_invalid_sizes() {
+    assert!(try_get_unique_coset_shifts::<F>(0, 1).is_err());
+    if usize::BITS > 32 {
+        assert!(try_get_unique_coset_shifts::<F>(1usize << 32, 1).is_err());
+    }
+    assert!(try_get_unique_coset_shifts::<F>(7, 1).is_err());
+
+    let valid = try_get_unique_coset_shifts::<F>(1 << 5, 4).unwrap();
+    assert_eq!(valid, get_unique_coset_shifts::<F>(1 << 5, 4));
 }
 
 #[test]

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -479,6 +479,23 @@ fn subgroup_size_validation_rejects_invalid_sizes() {
 }
 
 #[test]
+fn zero_generator_hangs_rejected() {
+    assert!(F::try_generator_order(F::ZERO).is_err());
+    assert!(F::try_cyclic_subgroup_unknown_order(F::ZERO).is_err());
+
+    assert_eq!(
+        F::try_generator_order(F::primitive_root_of_unity(4)).unwrap(),
+        1 << 4
+    );
+    assert_eq!(
+        F::try_cyclic_subgroup_unknown_order(F::primitive_root_of_unity(3))
+            .unwrap()
+            .len(),
+        1 << 3
+    );
+}
+
+#[test]
 fn malformed_fri_oracle_metadata_rejected() {
     let instance = FriInstanceInfo::<F, D> {
         oracles: vec![FriOracleInfo {

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -33,6 +33,7 @@ use plonky2::gates::reducing::ReducingGate;
 use plonky2::gates::reducing_extension::ReducingExtensionGate;
 use plonky2::gates::util::StridedConstraintConsumer;
 use plonky2::hash::batch_merkle_tree::BatchMerkleTree;
+use plonky2::hash::hashing::hash_n_to_hash_len_delimited;
 use plonky2::hash::merkle_proofs::{
     verify_batch_merkle_proof_to_cap, verify_merkle_proof_to_cap, MerkleProof, MerkleProofTarget,
 };
@@ -1445,6 +1446,24 @@ fn merkle_poseidon_zero_suffix_leaf_collision_rejected() -> anyhow::Result<()> {
     assert!(verify_merkle_proof_to_cap(zero_extended_leaf, 0, &tree.cap, &proof).is_err());
 
     Ok(())
+}
+
+#[test]
+fn trailing_zero_hash_len_delimited_distinguishes_lengths() {
+    type P = <PoseidonHash as Hasher<F>>::Permutation;
+
+    let x = F::from_canonical_u64(123);
+    assert_eq!(
+        PoseidonHash::hash_no_pad(&[x]),
+        PoseidonHash::hash_no_pad(&[x, F::ZERO])
+    );
+
+    let h1 = hash_n_to_hash_len_delimited::<F, P>(&[x]);
+    let h2 = hash_n_to_hash_len_delimited::<F, P>(&[x, F::ZERO]);
+    let h3 = hash_n_to_hash_len_delimited::<F, P>(&[x, F::ZERO, F::ZERO]);
+    assert_ne!(h1, h2);
+    assert_ne!(h2, h3);
+    assert_ne!(h1, h3);
 }
 
 #[test]

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -15,11 +15,11 @@ use plonky2::fri::proof::{
     FriChallenges, FriFinalPolys, FriFinalPolysTarget, FriInitialTreeProof, FriProof,
     FriProofTarget, FriQueryRound,
 };
+use plonky2::fri::structure::{
+    FriBatchInfo, FriInstanceInfo, FriOpeningBatch, FriOpeningExpression, FriOpenings,
+    FriOracleInfo, FriPolynomialInfo,
+};
 use plonky2::fri::{
-    structure::{
-        FriBatchInfo, FriInstanceInfo, FriOpeningBatch, FriOpeningExpression, FriOpenings,
-        FriOracleInfo, FriPolynomialInfo,
-    },
     validate_batch_fri_auxiliary_shape, validate_fri_auxiliary_shape, FriBatchMaskingParams,
     FriChallenger, FriConfig, FriFinalPolyLayout, FriParams, FriReductionStrategy,
 };

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -835,6 +835,24 @@ fn matched_fri_degree_bits_deserialize() {
 }
 
 #[test]
+fn malformed_verifier_metadata_rejected() {
+    let data = simple_circuit_data();
+    let serializer = DefaultGateSerializer;
+    let mut common = data.common.clone();
+
+    common.public_initial_degree_bits = F::TWO_ADICITY;
+    common.fri_params.degree_bits = common.public_initial_degree_bits;
+
+    assert!(common.check_valid().is_err());
+    let bytes = common.to_bytes(&serializer).unwrap();
+    assert!(CommonCircuitData::<F, D>::from_bytes(bytes, &serializer).is_err());
+
+    data.common.check_valid().unwrap();
+    let bytes = data.common.to_bytes(&serializer).unwrap();
+    assert!(CommonCircuitData::<F, D>::from_bytes(bytes, &serializer).is_ok());
+}
+
+#[test]
 fn forged_proving_key_crashes_rejected() -> anyhow::Result<()> {
     let config = CircuitConfig::standard_recursion_polyfri_zk_config();
     let mut builder = CircuitBuilder::<F, D>::new(config);

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -496,6 +496,23 @@ fn zero_generator_hangs_rejected() {
 }
 
 #[test]
+fn zero_inputs_batch_inversion_rejected() {
+    assert!(F::try_batch_multiplicative_inverse(&[F::ONE, F::ZERO, F::TWO]).is_err());
+    assert!(try_interpolate2([(F::ONE, F::ZERO), (F::ONE, F::TWO)], F::ZERO).is_err());
+
+    let xs = [
+        F::from_canonical_u64(11),
+        F::from_canonical_u64(13),
+        F::from_canonical_u64(17),
+    ];
+    let invs = F::try_batch_multiplicative_inverse(&xs).unwrap();
+    assert_eq!(invs, F::batch_multiplicative_inverse(&xs));
+    for (&x, &x_inv) in xs.iter().zip(&invs) {
+        assert_eq!(x * x_inv, F::ONE);
+    }
+}
+
+#[test]
 fn malformed_fri_oracle_metadata_rejected() {
     let instance = FriInstanceInfo::<F, D> {
         oracles: vec![FriOracleInfo {

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -467,6 +467,39 @@ fn zero_poly_on_coset_valid_domain_works() {
 }
 
 #[test]
+fn malformed_domains_rejected_before_fft() {
+    assert!(PolynomialValues::<F>::try_new(vec![]).is_err());
+    assert!(PolynomialValues::<F>::try_new(vec![F::ZERO; 3]).is_err());
+
+    let mut timing = TimingTree::default();
+    let malformed = PolynomialValues::<F> {
+        values: vec![F::ZERO; 3],
+    };
+    assert!(
+        plonky2::fri::oracle::PolynomialBatch::<F, C, D>::try_from_values(
+            vec![malformed.clone()],
+            1,
+            false,
+            0,
+            &mut timing,
+            None,
+        )
+        .is_err()
+    );
+    assert!(BatchFriOracle::<F, C, D>::try_from_values(
+        vec![malformed],
+        1,
+        false,
+        0,
+        &mut timing,
+        &[None],
+    )
+    .is_err());
+
+    assert!(PolynomialValues::<F>::try_new(vec![F::ZERO; 4]).is_ok());
+}
+
+#[test]
 fn subgroup_size_validation_rejects_invalid_sizes() {
     assert!(try_get_unique_coset_shifts::<F>(0, 1).is_err());
     if usize::BITS > 32 {

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -33,7 +33,7 @@ use plonky2::gates::reducing::ReducingGate;
 use plonky2::gates::reducing_extension::ReducingExtensionGate;
 use plonky2::gates::util::StridedConstraintConsumer;
 use plonky2::hash::batch_merkle_tree::BatchMerkleTree;
-use plonky2::hash::hashing::hash_n_to_hash_len_delimited;
+use plonky2::hash::hashing::{hash_n_to_hash_len_delimited, hash_n_to_m_no_pad};
 use plonky2::hash::merkle_proofs::{
     verify_batch_merkle_proof_to_cap, verify_merkle_proof_to_cap, MerkleProof, MerkleProofTarget,
 };
@@ -1464,6 +1464,20 @@ fn trailing_zero_hash_len_delimited_distinguishes_lengths() {
     assert_ne!(h1, h2);
     assert_ne!(h2, h3);
     assert_ne!(h1, h3);
+}
+
+#[test]
+fn zero_output_hash_returns_empty() {
+    type P = <PoseidonHash as Hasher<F>>::Permutation;
+
+    assert!(hash_n_to_m_no_pad::<F, P>(&[F::ONE, F::TWO], 0).is_empty());
+    assert_eq!(hash_n_to_m_no_pad::<F, P>(&[F::ONE], 3).len(), 3);
+
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    assert!(builder
+        .hash_n_to_m_no_pad::<PoseidonHash>(Vec::new(), 0)
+        .is_empty());
 }
 
 #[test]

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -1264,6 +1264,46 @@ fn forged_lookup_rows_returns_err_not_panic() -> anyhow::Result<()> {
 }
 
 #[test]
+fn zero_slot_generator_rejected() -> anyhow::Result<()> {
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let input = builder.add_virtual_target();
+    let table = std::sync::Arc::new(vec![(0u16, 10u16), (1u16, 11u16)]);
+    let table_index = builder.add_lookup_table_from_pairs(table);
+    let output = builder.add_lookup_from_index(input, table_index);
+    builder.register_public_input(output);
+
+    let data = builder.build::<C>();
+    let mut valid = PartialWitness::new();
+    valid.set_target(input, F::ONE)?;
+    let proof = data.prove(valid)?;
+    assert_eq!(proof.public_inputs, vec![F::from_canonical_u16(11)]);
+    data.verify(proof)?;
+
+    let rows = data.prover_only.lookup_rows[0].clone();
+    let mut forged = Vec::new();
+    forged.write_usize(rows.last_lut_gate).unwrap();
+    forged.write_usize(0).unwrap();
+    forged.write_usize(0).unwrap();
+    forged.write_usize(rows.last_lut_gate).unwrap();
+    forged.write_usize(0).unwrap();
+    let mut buffer = Buffer::new(&forged);
+    assert!(
+        <plonky2::gates::lookup_table::LookupTableGenerator as plonky2::iop::generator::SimpleGenerator<
+            F,
+            D,
+        >>::deserialize(&mut buffer, &data.common)
+        .is_err()
+    );
+
+    let mut narrow_lookup = CircuitConfig::standard_recursion_config();
+    narrow_lookup.num_routed_wires = 2;
+    assert!(narrow_lookup.check_lookup_widths().is_err());
+
+    Ok(())
+}
+
+#[test]
 fn merkle_poseidon_zero_suffix_leaf_collision_rejected() -> anyhow::Result<()> {
     let leaf = vec![
         F::from_canonical_u64(1),

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -4,6 +4,7 @@ use hashbrown::HashMap;
 use plonky2::batch_fri::oracle::BatchFriOracle;
 use plonky2::batch_fri::prover::batch_fri_proof;
 use plonky2::batch_fri::verifier::verify_batch_fri_proof;
+use plonky2::field::interpolation::{try_barycentric_weights, try_interpolant, try_interpolate2};
 use plonky2::field::packable::Packable;
 use plonky2::field::packed::PackedField;
 use plonky2::field::polynomial::{PolynomialCoeffs, PolynomialValues};
@@ -330,6 +331,29 @@ fn interpolation_generator_nonzero_shift_still_proves() -> anyhow::Result<()> {
     let data = add_zero_value_coset_interpolation_circuit(F::ONE);
     let proof = data.prove(PartialWitness::new())?;
     data.verify(proof)
+}
+
+#[test]
+fn malformed_interpolation_inputs_rejected() {
+    let duplicate = vec![(F::ONE, F::ZERO), (F::ONE, F::TWO)];
+    assert!(try_barycentric_weights(&duplicate).is_err());
+    assert!(try_interpolant(&duplicate).is_err());
+    assert!(try_interpolate2([(F::ONE, F::ZERO), (F::ONE, F::TWO)], F::ZERO).is_err());
+
+    let empty: Vec<(F, F)> = Vec::new();
+    assert!(try_barycentric_weights(&empty).is_err());
+    assert!(try_interpolant(&empty).is_err());
+
+    let data = simple_circuit_data();
+    let mut malformed_gate = Vec::new();
+    malformed_gate.write_usize(F::TWO_ADICITY + 1).unwrap();
+    malformed_gate.write_usize(2).unwrap();
+    malformed_gate.write_usize(0).unwrap();
+    let mut buffer = Buffer::new(&malformed_gate);
+    assert!(
+        <CosetInterpolationGate<F, D> as Gate<F, D>>::deserialize(&mut buffer, &data.common)
+            .is_err()
+    );
 }
 
 #[test]

--- a/verifier/src/gates/reducing.rs
+++ b/verifier/src/gates/reducing.rs
@@ -2,6 +2,8 @@
 use alloc::{format, string::String, vec::Vec};
 use core::ops::Range;
 
+use qp_plonky2_core::circuit_config::reducing_base_capacity;
+
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::gates::gate::VerificationGate;
 use crate::gates::util::StridedConstraintConsumer;
@@ -9,7 +11,6 @@ use crate::hash::hash_types::RichField;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::vars::{EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::{Buffer, IoResult, Read, Write};
-use qp_plonky2_core::circuit_config::reducing_base_capacity;
 
 /// Computes `sum alpha^i c_i` for a vector `c_i` of `num_coeffs` elements of the base field.
 #[derive(Debug, Default, Clone)]

--- a/verifier/src/gates/reducing_extension.rs
+++ b/verifier/src/gates/reducing_extension.rs
@@ -2,6 +2,8 @@
 use alloc::{format, string::String, vec::Vec};
 use core::ops::Range;
 
+use qp_plonky2_core::circuit_config::reducing_extension_capacity;
+
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::gates::gate::VerificationGate;
 use crate::gates::util::StridedConstraintConsumer;
@@ -9,7 +11,6 @@ use crate::hash::hash_types::RichField;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::vars::{EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::{Buffer, IoResult, Read, Write};
-use qp_plonky2_core::circuit_config::reducing_extension_capacity;
 
 /// Computes `sum alpha^i c_i` for a vector `c_i` of `num_coeffs` elements of the extension field.
 #[derive(Debug, Clone, Default)]

--- a/verifier/src/plonk/circuit_data.rs
+++ b/verifier/src/plonk/circuit_data.rs
@@ -258,6 +258,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CommonVerifierData<F, D> {
             .fri_config
             .required_proof_of_work_leading_zeros::<F>()
             .map_err(|_| "invalid FRI proof-of-work bits")?;
+        self.check_field_degree_bounds()?;
 
         // Quotient degree must fit within FRI rate.
         let quotient_degree_bits = crate::util::log2_ceil(self.quotient_degree_factor);
@@ -279,6 +280,45 @@ impl<F: RichField + Extendable<D>, const D: usize> CommonVerifierData<F, D> {
         }
 
         check_gate_id_collisions(&self.gates)?;
+
+        Ok(())
+    }
+
+    fn check_field_degree_bounds(&self) -> Result<(), &'static str> {
+        if self.trace_degree_bits > F::TWO_ADICITY {
+            return Err("trace_degree_bits exceeds field two-adicity");
+        }
+        if self.public_initial_degree_bits > F::TWO_ADICITY {
+            return Err("public_initial_degree_bits exceeds field two-adicity");
+        }
+        if self.fri_params.degree_bits > F::TWO_ADICITY {
+            return Err("FRI degree_bits exceeds field two-adicity");
+        }
+
+        let trace_lde_bits = self
+            .trace_degree_bits
+            .checked_add(self.config.fri_config.rate_bits)
+            .ok_or("trace LDE degree overflow")?;
+        if trace_lde_bits > F::TWO_ADICITY {
+            return Err("trace LDE degree exceeds field two-adicity");
+        }
+
+        let public_lde_bits = self
+            .public_initial_degree_bits
+            .checked_add(self.config.fri_config.rate_bits)
+            .ok_or("public initial LDE degree overflow")?;
+        if public_lde_bits > F::TWO_ADICITY {
+            return Err("public initial LDE degree exceeds field two-adicity");
+        }
+
+        let fri_lde_bits = self
+            .fri_params
+            .degree_bits
+            .checked_add(self.fri_params.config.rate_bits)
+            .ok_or("FRI LDE degree overflow")?;
+        if fri_lde_bits > F::TWO_ADICITY {
+            return Err("FRI LDE degree exceeds field two-adicity");
+        }
 
         Ok(())
     }

--- a/verifier/src/plonk/circuit_data.rs
+++ b/verifier/src/plonk/circuit_data.rs
@@ -248,6 +248,9 @@ impl<F: RichField + Extendable<D>, const D: usize> CommonVerifierData<F, D> {
         self.config.check_valid()?;
         self.config.check_reducing_widths::<D>()?;
         self.config.check_extension_gate_widths::<D>()?;
+        if !self.luts.is_empty() || self.num_lookup_polys != 0 || self.num_lookup_selectors != 0 {
+            self.config.check_lookup_widths()?;
+        }
         self.fri_params
             .check_valid()
             .map_err(|_| "invalid FRI params")?;


### PR DESCRIPTION
## V12 audit (8/10): medium lookup / interpolation / subgroup hardening

Part of the stack splitting #38 into reviewable slices. Stacked on `v12-audit/07-medium-dos-artifact`.

Addresses **9** V12 audit finding(s):

| Finding | Severity | Title | Commit |
|---|---|---|---|
| #64671 | Medium | Zero-slot generator divide-by-zero | `492b9733` |
| #64677 | Medium | Malformed inputs trigger panics | `4d7c909a` |
| #64678 | Medium | Unchecked subgroup size panics | `2a71b8b3` |
| #64685 | Medium | Zero generator hangs subgroup helpers | `f9f3c969` |
| #64686 | Medium | Zero inputs panic batch inversion | `6b619d22` |
| #64687 | Medium | Malformed verifier metadata triggers panic | `5192053c` |
| #64690 | Medium | Malformed domains panic in release | `c758e2bf` |
| #64701 | Medium | Trailing-zero hash collisions | `9ad1b7f8` |
| #64702 | Medium | Zero-output request never terminates | `3725f474` |

---

<details>
<summary><b>#64671 · Medium · Zero-slot generator divide-by-zero</b></summary>

**Description**

`LookupTableGenerator::deserialize` accepts an arbitrary serialized `num_slots`, but `run_once` assumes that value is nonzero and immediately calls `self.lut.len().div_ceil(self.num_slots)`. The same generator declares no dependencies, so the witness-generation scheduler will execute it as soon as proving starts. A malicious prover artifact can therefore embed a `LookupTableGenerator` with `num_slots == 0` and trigger a division-by-zero panic during `prove()` or witness generation. This is especially dangerous because it happens after successful deserialization of the outer structure, so callers that expect `Result`-based failure handling still get process-level failure. The bug is fully controlled by serialized generator bytes and does not require a valid proof.

**Root cause**

`LookupTableGenerator::deserialize` does not validate invariants like `num_slots > 0`, while `run_once` performs arithmetic that requires a positive slot count and the scheduler runs the generator immediately because `dependencies()` is empty.

**Impact**

Anyone who can supply serialized prover data can crash proof generation on demand by forcing witness generation to execute a malformed lookup-table generator. This turns artifact loading into a denial-of-service vector against services that perform proving for user-submitted jobs.

</details>

<details>
<summary><b>#64677 · Medium · Malformed inputs trigger panics</b></summary>

**Description**

The exported interpolation helpers accept attacker-controlled point sets but enforce their preconditions with panicking operations instead of returning an error. `barycentric_weights` multiplies all pairwise x-coordinate differences and feeds them into `Field::batch_multiplicative_inverse`; any duplicate abscissa makes one product zero, which reaches `inverse().expect("Tried to invert zero")` and panics. `interpolant` also assumes a non-empty, supported-size domain and immediately derives `n_log = log2_ceil(points.len())` before calling `F::two_adic_subgroup(n_log)`, which asserts when `points` is empty or exceeds the field's two-adic capacity. `interpolate2` has the same issue for its two-point special case via `assert_ne!(a0, b0)`. Because these functions are public in a reusable library, downstream services that feed untrusted interpolation queries into them can be crashed with malformed inputs.

**Root cause**

The module treats input validity as an unchecked precondition: it never verifies distinct x-coordinates, non-empty input, or `points.len() <= 2^{F::TWO_ADICITY}` before reaching `assert!`/`assert_ne!`/`expect`-based failure paths in shared field helpers.

**Impact**

An attacker who can supply interpolation points to a consumer of this library can trigger deterministic panics with duplicate x-coordinates, an empty point list, or an oversized list. Depending on the consumer's panic strategy, this can abort the entire process or at minimum tear down the current worker/request, enabling repeated denial of service against proving or verification endpoints.

</details>

<details>
<summary><b>#64678 · Medium · Unchecked subgroup size panics</b></summary>

**Description**

`get_unique_coset_shifts` divides by `(subgroup_size as u32)` before validating the input. Because the API accepts a `usize`, an attacker can pass `0` or any 64-bit value whose low 32 bits are zero, making the divisor zero after truncation and triggering an immediate panic. The same narrowing also makes the function incorrect for larger valid subgroup sizes supported by extension fields, because the bound check is computed from the truncated value rather than the real subgroup order. In a downstream prover or verifier service that exposes coset/domain selection, a single crafted request can therefore crash the worker instead of returning an error.

**Root cause**

The function narrows `subgroup_size` from `usize` to `u32` inside the divisor expression and performs the division before any explicit validation. This both permits division-by-zero panics and computes `num_cosets` from a truncated subgroup order.

**Impact**

An attacker who can influence the subgroup size can cheaply trigger a panic and knock over proof-generation or verification requests that call this helper. If the embedding service treats panics as process-fatal, this becomes a straightforward availability loss for the whole worker.

</details>

<details>
<summary><b>#64685 · Medium · Zero generator hangs subgroup helpers</b></summary>

**Description**

The subgroup-order helpers never validate that the supplied `generator` is nonzero before iterating over `generator.powers()`. For `generator == Self::ZERO`, that iterator yields `1, 0, 0, 0, ...`: `cyclic_subgroup_unknown_order` only stops when it sees `1` after the first element, and `generator_order` waits forever for `.position(|y| y.is_one())`. As a result, `cyclic_subgroup_unknown_order` keeps pushing zeros into a `Vec` until memory is exhausted, while `generator_order` spins indefinitely. Any downstream API that accepts an attacker-controlled field element and forwards it into either helper can therefore be forced into a reliable denial of service with a single zero input.

**Root cause**

`cyclic_subgroup_unknown_order` and `generator_order` assume every input lies in the multiplicative group, but they accept arbitrary `Field` elements. Their termination conditions only recognize a return to `1`, so `Self::ZERO` produces an infinite sequence that never satisfies the stop condition.

**Impact**

An attacker can hang a worker thread or crash a process through memory exhaustion by supplying `0` as the generator to code paths that use these helpers. Because the methods are safe, public trait defaults, downstream consumers get no type-level warning that this input can wedge the computation.

</details>

<details>
<summary><b>#64686 · Medium · Zero inputs panic batch inversion</b></summary>

**Description**

`batch_multiplicative_inverse` blindly applies Montgomery's trick and eventually calls `inverse()` on the product of the input slice. If any supplied element is zero, that aggregate product is zero, and `inverse()` panics with `Tried to invert zero` instead of returning an error. This is reachable through adjacent public helpers such as `barycentric_weights`, where duplicate x-coordinates make one of the per-point denominator products equal zero. A downstream service that batch-inverts attacker-derived values, or interpolates attacker-supplied points, can therefore be crashed by a single malformed request.

**Root cause**

`batch_multiplicative_inverse` has no zero-element handling and calls `inverse()` rather than `try_inverse()` on the combined product. Because `inverse()` panics on zero, any zero anywhere in the slice escalates to a hard failure.

**Impact**

An attacker can trigger a panic and terminate the current request handler or process by including a zero in a batch inversion input, or by submitting duplicate interpolation points that create such a zero internally. That turns malformed input into a reliable availability failure instead of a handled validation error.

</details>

<details>
<summary><b>#64687 · Medium · Malformed verifier metadata triggers panic</b></summary>

**Description**

`primitive_root_of_unity` enforces `n_log <= Self::TWO_ADICITY` with a hard `assert!`, so oversized exponents abort the process instead of returning a recoverable error. Adjacent verifier code deserializes `trace_degree_bits`, `public_initial_degree_bits`, and FRI parameters from bytes without checking that these derived exponents stay within the field's supported two-adicity, then uses them during compressed-proof verification and inference. In particular, compressed verification computes `log_n = public_initial_degree_bits + rate_bits` and passes it straight into `F::primitive_root_of_unity(log_n)`. A consumer that accepts serialized verifier metadata or circuit data from an untrusted source can therefore be crashed with a malformed artifact before any proof failure is reported.

**Root cause**

`primitive_root_of_unity` uses `assert!` on a caller-controlled exponent, and adjacent deserialization/verification paths do not validate the loaded degree parameters against `F::TWO_ADICITY` before invoking it. The API boundary treats serialized metadata as data, but this helper treats bad parameters as unrecoverable programmer bugs.

**Impact**

An attacker can supply crafted serialized circuit metadata that makes compressed proof verification panic, taking down the verifying request or process. This converts malformed external data into a reliable denial of service rather than a clean verification error.

</details>

<details>
<summary><b>#64690 · Medium · Malformed domains panic in release</b></summary>

**Description**

`PolynomialValues::new` only checks that the evaluation vector length is a valid two-adic subgroup size inside a `debug_assert!`. In optimized builds, zero-length, non-power-of-two, or oversized vectors are accepted, and `From<Vec<F>>` forwards into the same unchecked constructor. Later methods such as `ifft`, `lde`, and `degree_plus_one` feed that malformed state into the FFT layer, which immediately calls `log2_strict(n)` and indexes the buffer as if the domain were valid. This turns attacker-controlled polynomial lengths into deterministic panics instead of a recoverable error.

**Root cause**

`PolynomialValues::new` enforces the subgroup-size invariant with `debug_assert!` instead of a runtime check, so invalid internal state is reachable in release builds and later FFT-based methods assume the invariant still holds.

**Impact**

A downstream prover or verifier service that builds `PolynomialValues` from untrusted artifacts can be crashed on demand with malformed vector lengths. Repeated submissions can keep the service unavailable, since the library aborts the operation with a panic rather than rejecting the input cleanly.

</details>

<details>
<summary><b>#64701 · Medium · Trailing-zero hash collisions</b></summary>

**Description**

`hash_n_to_m_no_pad` implements an overwrite-mode sponge without any end-of-input marker. When the message fits in a single incomplete rate block, the permutation starts from an all-zero state and only the provided positions are overwritten before the first permutation. As a result, appending one or more zero field elements to the end of such a message does not change the absorbed state at all, so distinct inputs like `[x]` and `[x, F::ZERO]` hash to the same digest. `hash_n_to_hash_no_pad` exposes this behavior directly, and `PoseidonHash::hash_no_pad` uses it as its concrete hash implementation.

**Root cause**

`hash_n_to_m_no_pad` overwrites the sponge rate cells and never encodes the message length or a terminator before permuting. Because the initial state is all zeros, omitted trailing elements are indistinguishable from explicit trailing `F::ZERO` elements in the final partial block.

**Impact**

Any downstream consumer that uses `hash_n_to_hash_no_pad` / `PoseidonHash::hash_no_pad` as a variable-length commitment loses binding: an attacker can substitute a message with a different zero-suffixed message while keeping the same digest. If that digest is used to identify statements, authorize data, or bind proof inputs in an embedding application, the attacker can make one committed value verify as another distinct value.

</details>

<details>
<summary><b>#64702 · Medium · Zero-output request never terminates</b></summary>

**Description**

`hash_n_to_m_no_pad` does not handle `num_outputs == 0`. The function always enters the squeezing loop, pushes an item into `outputs` before checking the termination condition, and only returns when `outputs.len() == num_outputs`. Since `outputs.len()` starts at `0` and becomes `1` before the first comparison, the equality can never be satisfied for a zero-length request. The function therefore spins forever while continuously growing `outputs`, turning a zero-output query into an unbounded CPU and memory denial of service.

**Root cause**

`hash_n_to_m_no_pad` lacks an early return for `num_outputs == 0` and checks its exit condition only after appending a squeezed element. That makes the target length `0` unreachable.

**Impact**

Any consumer that forwards attacker-controlled output lengths into this helper can be crashed with a single `num_outputs = 0` request. The process will keep permuting and allocating until it exhausts CPU time or memory, taking down the caller or verifier service.

</details>
