### PR TITLE
V12 audit (9/10): medium Merkle binding, compressed-proof & circuit/gate metadata validation

### DIFF
--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -33,3 +33,4 @@ finding	severity	class	commit	status	notes
 64708	Medium	merkle-hash-binding	86bb5cd5d	test-only-covered	Short Merkle leaves are not uniquely committed; root fixed by c5f8b727a
 64709	Medium	merkle-hash-binding	a1bf921e8	fixed	Poseidon2 recursive Merkle hashing ignores branch direction
 64710	Medium	merkle-hash-binding	23787a213	fixed	Generic circuit hashing does not implement Poseidon2 semantics
+64711	Medium	untrusted-artifact-validation	b6a404702	fixed	Unvalidated circuit metadata can panic or hang verification

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -28,3 +28,4 @@ finding	severity	class	commit	status	notes
 64690	Medium	untrusted-artifact-validation	c758e2bf8	fixed	Malformed domains panic in release
 64701	Medium	merkle-hash-binding	9ad1b7f85	fixed	Trailing-zero hash collisions
 64702	Medium	runtime-dos-preconditions	3725f4746	fixed	Zero-output request never terminates
+64706	Medium	untrusted-artifact-validation	c5cd9414f	test-only-covered	Malformed Merkle caps can panic proof verification; root fixed by f6eaccba9

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -32,3 +32,4 @@ finding	severity	class	commit	status	notes
 64707	Medium	untrusted-artifact-validation	4932fe0eb	fixed	Malformed compressed proofs panic instead of returning errors
 64708	Medium	merkle-hash-binding	86bb5cd5d	test-only-covered	Short Merkle leaves are not uniquely committed; root fixed by c5f8b727a
 64709	Medium	merkle-hash-binding	a1bf921e8	fixed	Poseidon2 recursive Merkle hashing ignores branch direction
+64710	Medium	merkle-hash-binding	23787a213	fixed	Generic circuit hashing does not implement Poseidon2 semantics

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -34,3 +34,4 @@ finding	severity	class	commit	status	notes
 64709	Medium	merkle-hash-binding	a1bf921e8	fixed	Poseidon2 recursive Merkle hashing ignores branch direction
 64710	Medium	merkle-hash-binding	23787a213	fixed	Generic circuit hashing does not implement Poseidon2 semantics
 64711	Medium	untrusted-artifact-validation	b6a404702	fixed	Unvalidated circuit metadata can panic or hang verification
+64712	Medium	untrusted-artifact-validation	f30021de9	fixed	Malformed gate metadata can panic circuit loading and verification

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -31,3 +31,4 @@ finding	severity	class	commit	status	notes
 64706	Medium	untrusted-artifact-validation	c5cd9414f	test-only-covered	Malformed Merkle caps can panic proof verification; root fixed by f6eaccba9
 64707	Medium	untrusted-artifact-validation	4932fe0eb	fixed	Malformed compressed proofs panic instead of returning errors
 64708	Medium	merkle-hash-binding	86bb5cd5d	test-only-covered	Short Merkle leaves are not uniquely committed; root fixed by c5f8b727a
+64709	Medium	merkle-hash-binding	a1bf921e8	fixed	Poseidon2 recursive Merkle hashing ignores branch direction

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -35,3 +35,4 @@ finding	severity	class	commit	status	notes
 64710	Medium	merkle-hash-binding	23787a213	fixed	Generic circuit hashing does not implement Poseidon2 semantics
 64711	Medium	untrusted-artifact-validation	b6a404702	fixed	Unvalidated circuit metadata can panic or hang verification
 64712	Medium	untrusted-artifact-validation	f30021de9	fixed	Malformed gate metadata can panic circuit loading and verification
+64713	Medium	untrusted-artifact-validation	7b990e4c4	fixed	Lookup deserializers panic on unvalidated serialized indices

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -29,3 +29,4 @@ finding	severity	class	commit	status	notes
 64701	Medium	merkle-hash-binding	9ad1b7f85	fixed	Trailing-zero hash collisions
 64702	Medium	runtime-dos-preconditions	3725f4746	fixed	Zero-output request never terminates
 64706	Medium	untrusted-artifact-validation	c5cd9414f	test-only-covered	Malformed Merkle caps can panic proof verification; root fixed by f6eaccba9
+64707	Medium	untrusted-artifact-validation	4932fe0eb	fixed	Malformed compressed proofs panic instead of returning errors

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -30,3 +30,4 @@ finding	severity	class	commit	status	notes
 64702	Medium	runtime-dos-preconditions	3725f4746	fixed	Zero-output request never terminates
 64706	Medium	untrusted-artifact-validation	c5cd9414f	test-only-covered	Malformed Merkle caps can panic proof verification; root fixed by f6eaccba9
 64707	Medium	untrusted-artifact-validation	4932fe0eb	fixed	Malformed compressed proofs panic instead of returning errors
+64708	Medium	merkle-hash-binding	86bb5cd5d	test-only-covered	Short Merkle leaves are not uniquely committed; root fixed by c5f8b727a

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -36,3 +36,4 @@ finding	severity	class	commit	status	notes
 64711	Medium	untrusted-artifact-validation	b6a404702	fixed	Unvalidated circuit metadata can panic or hang verification
 64712	Medium	untrusted-artifact-validation	f30021de9	fixed	Malformed gate metadata can panic circuit loading and verification
 64713	Medium	untrusted-artifact-validation	7b990e4c4	fixed	Lookup deserializers panic on unvalidated serialized indices
+64714	Medium	untrusted-artifact-validation	c2c88e97f	fixed	Empty lookup tables panic during build and witness generation

--- a/plonky2/src/batch_fri/oracle.rs
+++ b/plonky2/src/batch_fri/oracle.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "std"))]
-use alloc::{format, vec::Vec};
+use alloc::{format, vec, vec::Vec};
 
 use anyhow::{ensure, Result};
 use itertools::Itertools;

--- a/plonky2/src/batch_fri/verifier.rs
+++ b/plonky2/src/batch_fri/verifier.rs
@@ -10,12 +10,11 @@ use crate::fri::proof::{
     eval_final_polys_at_point, FriChallenges, FriInitialTreeProof, FriProof, FriQueryRound,
 };
 use crate::fri::structure::{FriBatchInfo, FriInstanceInfo, FriOpenings};
-use crate::fri::validate_batch_fri_auxiliary_shape;
 use crate::fri::verifier::{
     compute_evaluation, eval_opening_expression, fri_verify_proof_of_work,
     PrecomputedReducedOpenings,
 };
-use crate::fri::FriParams;
+use crate::fri::{validate_batch_fri_auxiliary_shape, FriParams};
 use crate::hash::hash_types::RichField;
 use crate::hash::merkle_proofs::{verify_batch_merkle_proof_to_cap, verify_merkle_proof_to_cap};
 use crate::hash::merkle_tree::MerkleCap;

--- a/plonky2/src/fri/mod.rs
+++ b/plonky2/src/fri/mod.rs
@@ -23,15 +23,14 @@ pub mod validate_shape;
 pub mod verifier;
 pub mod witness_util;
 
-pub use validate_shape::{
-    validate_batch_fri_auxiliary_shape, validate_batch_fri_proof_shape,
-    validate_fri_auxiliary_shape,
-};
-
 // Re-export FRI types from core
 pub use qp_plonky2_core::{
     FriBatchMaskingParams, FriChallenger, FriConfig, FriConfigObserve, FriFinalPolyLayout,
     FriParams, FriParamsObserve, FriReductionStrategy,
+};
+pub use validate_shape::{
+    validate_batch_fri_auxiliary_shape, validate_batch_fri_proof_shape,
+    validate_fri_auxiliary_shape,
 };
 
 /// Trait for observing FRI configuration in a RecursiveChallenger (circuit target version).

--- a/plonky2/src/gadgets/lookup.rs
+++ b/plonky2/src/gadgets/lookup.rs
@@ -47,19 +47,48 @@ pub const OTHER_TABLE: [u16; 256] = [
 pub const SMALLER_TABLE: [u16; 8] = [2, 24, 56, 100, 128, 16, 20, 49];
 
 impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
+    /// Fallible version of [`Self::add_lookup_table_from_pairs`] for untrusted table inputs.
+    pub fn try_add_lookup_table_from_pairs(
+        &mut self,
+        table: LookupTable,
+    ) -> Result<usize, &'static str> {
+        self.try_update_luts_from_pairs(table)
+    }
+
     /// Adds a lookup table to the list of stored lookup tables `self.luts` based on a table of (input, output) pairs. It returns the index of the LUT within `self.luts`.
     pub fn add_lookup_table_from_pairs(&mut self, table: LookupTable) -> usize {
-        self.update_luts_from_pairs(table)
+        self.try_add_lookup_table_from_pairs(table)
+            .expect("lookup table must not be empty")
+    }
+
+    /// Fallible version of [`Self::add_lookup_table_from_table`] for untrusted table inputs.
+    pub fn try_add_lookup_table_from_table(
+        &mut self,
+        inps: &[u16],
+        outs: &[u16],
+    ) -> Result<usize, &'static str> {
+        self.try_update_luts_from_table(inps, outs)
     }
 
     /// Adds a lookup table to the list of stored lookup tables `self.luts` based on a table, represented as a slice `&[u16]` of inputs and a slice `&[u16]` of outputs. It returns the index of the LUT within `self.luts`.
     pub fn add_lookup_table_from_table(&mut self, inps: &[u16], outs: &[u16]) -> usize {
-        self.update_luts_from_table(inps, outs)
+        self.try_add_lookup_table_from_table(inps, outs)
+            .expect("lookup table inputs and outputs must be non-empty and equally long")
+    }
+
+    /// Fallible version of [`Self::add_lookup_table_from_fn`] for untrusted table inputs.
+    pub fn try_add_lookup_table_from_fn(
+        &mut self,
+        f: fn(u16) -> u16,
+        inputs: &[u16],
+    ) -> Result<usize, &'static str> {
+        self.try_update_luts_from_fn(f, inputs)
     }
 
     /// Adds a lookup table to the list of stored lookup tables `self.luts` based on a function. It returns the index of the LUT within `self.luts`.
     pub fn add_lookup_table_from_fn(&mut self, f: fn(u16) -> u16, inputs: &[u16]) -> usize {
-        self.update_luts_from_fn(f, inputs)
+        self.try_add_lookup_table_from_fn(f, inputs)
+            .expect("lookup table must not be empty")
     }
 
     /// Adds a lookup (input, output) pair to the stored lookups. Takes a `Target` input and returns a `Target` output.

--- a/plonky2/src/gates/lookup.rs
+++ b/plonky2/src/gates/lookup.rs
@@ -246,11 +246,27 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Loo
         let row = src.read_usize()?;
         let slot_nb = src.read_usize()?;
         let lut_index = src.read_usize()?;
+        let num_slots = LookupGate::num_slots(&common_data.config);
+        let degree = 1usize
+            .checked_shl(
+                common_data
+                    .trace_degree_bits
+                    .try_into()
+                    .unwrap_or(usize::BITS),
+            )
+            .ok_or(crate::util::serialization::IoError)?;
+        if num_slots == 0 || slot_nb >= num_slots || row >= degree {
+            return Err(crate::util::serialization::IoError);
+        }
+        let lut = common_data
+            .luts
+            .get(lut_index)
+            .ok_or(crate::util::serialization::IoError)?
+            .clone();
+        if lut.is_empty() {
+            return Err(crate::util::serialization::IoError);
+        }
 
-        Ok(Self {
-            row,
-            lut: common_data.luts[lut_index].clone(),
-            slot_nb,
-        })
+        Ok(Self { row, lut, slot_nb })
     }
 }

--- a/plonky2/src/gates/lookup_table.rs
+++ b/plonky2/src/gates/lookup_table.rs
@@ -274,7 +274,20 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Loo
         let last_lut_row = src.read_usize()?;
         let lut_index = src.read_usize()?;
         let expected_num_slots = LookupTableGate::num_slots(&common_data.config);
-        if expected_num_slots == 0 || num_slots != expected_num_slots || slot_nb >= num_slots {
+        let degree = 1usize
+            .checked_shl(
+                common_data
+                    .trace_degree_bits
+                    .try_into()
+                    .unwrap_or(usize::BITS),
+            )
+            .ok_or(crate::util::serialization::IoError)?;
+        if expected_num_slots == 0
+            || num_slots != expected_num_slots
+            || slot_nb >= num_slots
+            || row >= degree
+            || last_lut_row >= degree
+        {
             return Err(crate::util::serialization::IoError);
         }
         let lut = common_data

--- a/plonky2/src/gates/reducing.rs
+++ b/plonky2/src/gates/reducing.rs
@@ -8,6 +8,7 @@ use alloc::{
 use core::ops::Range;
 
 use anyhow::Result;
+use qp_plonky2_core::circuit_config::reducing_base_capacity;
 
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::gates::gate::Gate;
@@ -21,7 +22,6 @@ use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::{Buffer, IoResult, Read, Write};
-use qp_plonky2_core::circuit_config::reducing_base_capacity;
 
 /// Computes `sum alpha^i c_i` for a vector `c_i` of `num_coeffs` elements of the base field.
 #[derive(Debug, Default, Clone)]

--- a/plonky2/src/gates/reducing_extension.rs
+++ b/plonky2/src/gates/reducing_extension.rs
@@ -8,6 +8,7 @@ use alloc::{
 use core::ops::Range;
 
 use anyhow::Result;
+use qp_plonky2_core::circuit_config::reducing_extension_capacity;
 
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::gates::gate::Gate;
@@ -21,7 +22,6 @@ use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::{Buffer, IoResult, Read, Write};
-use qp_plonky2_core::circuit_config::reducing_extension_capacity;
 
 /// Computes `sum alpha^i c_i` for a vector `c_i` of `num_coeffs` elements of the extension field.
 #[derive(Debug, Clone, Default)]

--- a/plonky2/src/gates/selectors.rs
+++ b/plonky2/src/gates/selectors.rs
@@ -7,7 +7,6 @@
 use alloc::{vec, vec::Vec};
 
 use hashbrown::HashMap;
-
 // Re-export selector types from core
 pub use qp_plonky2_core::selectors::{LookupSelectors, SelectorsInfo, UNUSED_SELECTOR};
 

--- a/plonky2/src/hash/hashing.rs
+++ b/plonky2/src/hash/hashing.rs
@@ -23,7 +23,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         &mut self,
         inputs: Vec<Target>,
     ) -> HashOutTarget {
-        HashOutTarget::from_vec(self.hash_n_to_m_no_pad::<H>(inputs, NUM_HASH_OUT_ELTS))
+        H::hash_no_pad_circuit(self, inputs)
     }
 
     pub fn hash_n_to_m_no_pad<H: AlgebraicHasher<F>>(

--- a/plonky2/src/hash/poseidon2.rs
+++ b/plonky2/src/hash/poseidon2.rs
@@ -165,7 +165,7 @@ impl<F: RichField + P2Permuter> AlgebraicHasher<F> for Poseidon2Hash {
 
     fn permute_swapped<const D: usize>(
         inputs: Self::AlgebraicPermutation,
-        _swap: BoolTarget, // still ignored (semantics unchanged)
+        swap: BoolTarget,
         b: &mut CircuitBuilder<F, D>,
     ) -> Self::AlgebraicPermutation
     where
@@ -179,8 +179,15 @@ impl<F: RichField + P2Permuter> AlgebraicHasher<F> for Poseidon2Hash {
 
         // connect inputs
         for i in 0..SPONGE_WIDTH {
+            let input = if i < NUM_HASH_OUT_ELTS {
+                b.select(swap, inp[i + NUM_HASH_OUT_ELTS], inp[i])
+            } else if i < 2 * NUM_HASH_OUT_ELTS {
+                b.select(swap, inp[i - NUM_HASH_OUT_ELTS], inp[i])
+            } else {
+                inp[i]
+            };
             b.connect(
-                inp[i],
+                input,
                 Target::wire(row, Poseidon2Gate::<F, D>::wire_input(i)),
             );
         }

--- a/plonky2/src/hash/poseidon2.rs
+++ b/plonky2/src/hash/poseidon2.rs
@@ -199,6 +199,16 @@ impl<F: RichField + P2Permuter> AlgebraicHasher<F> for Poseidon2Hash {
         Poseidon2Permutation { state }
     }
 
+    fn hash_no_pad_circuit<const D: usize>(
+        builder: &mut CircuitBuilder<F, D>,
+        inputs: Vec<Target>,
+    ) -> HashOutTarget
+    where
+        F: RichField + Extendable<D>,
+    {
+        builder.hash_n_to_hash_no_pad_p2::<Self>(inputs)
+    }
+
     fn hash_merkle_leaf_circuit<const D: usize>(
         builder: &mut CircuitBuilder<F, D>,
         leaf_data: Vec<Target>,

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -800,11 +800,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         inputs.iter().map(|&input| (input, f(input))).collect()
     }
 
-    /// Given a function `f: fn(u16) -> u16`, adds a LUT to the circuit builder.
-    pub fn update_luts_from_fn(&mut self, f: fn(u16) -> u16, inputs: &[u16]) -> usize {
-        let lut = Arc::new(Self::get_lut_from_fn::<u16>(f, inputs));
-
-        // If the LUT `lut` is already stored in `self.luts`, return its index. Otherwise, append `table` to `self.luts` and return its index.
+    fn insert_lookup_table(&mut self, lut: LookupTable) -> usize {
         if let Some(idx) = self.is_stored(lut.clone()) {
             idx
         } else {
@@ -815,43 +811,67 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         }
     }
 
-    /// Adds a table to the vector of LUTs in the circuit builder, given a list of inputs and table values.
-    pub fn update_luts_from_table(&mut self, inputs: &[u16], table: &[u16]) -> usize {
-        assert!(
-            inputs.len() == table.len(),
-            "Inputs and table have incompatible lengths: {} and {}",
-            inputs.len(),
-            table.len()
-        );
+    /// Fallible version of [`Self::update_luts_from_fn`] for untrusted table inputs.
+    pub fn try_update_luts_from_fn(
+        &mut self,
+        f: fn(u16) -> u16,
+        inputs: &[u16],
+    ) -> Result<usize, &'static str> {
+        let lut = Arc::new(Self::get_lut_from_fn::<u16>(f, inputs));
+        if lut.is_empty() {
+            return Err("lookup table must not be empty");
+        }
+        Ok(self.insert_lookup_table(lut))
+    }
+
+    /// Given a function `f: fn(u16) -> u16`, adds a LUT to the circuit builder.
+    pub fn update_luts_from_fn(&mut self, f: fn(u16) -> u16, inputs: &[u16]) -> usize {
+        self.try_update_luts_from_fn(f, inputs)
+            .expect("lookup table must not be empty")
+    }
+
+    /// Fallible version of [`Self::update_luts_from_table`] for untrusted table inputs.
+    pub fn try_update_luts_from_table(
+        &mut self,
+        inputs: &[u16],
+        table: &[u16],
+    ) -> Result<usize, &'static str> {
+        if inputs.len() != table.len() {
+            return Err("lookup table inputs and outputs must have equal lengths");
+        }
+        if inputs.is_empty() {
+            return Err("lookup table must not be empty");
+        }
         let pairs = inputs
             .iter()
             .copied()
             .zip_eq(table.iter().copied())
             .collect();
         let lut: LookupTable = Arc::new(pairs);
+        Ok(self.insert_lookup_table(lut))
+    }
 
-        // If the LUT `lut` is already stored in `self.luts`, return its index. Otherwise, append `table` to `self.luts` and return its index.
-        if let Some(idx) = self.is_stored(lut.clone()) {
-            idx
-        } else {
-            self.luts.push(lut);
-            self.lut_to_lookups.push(vec![]);
-            assert!(self.luts.len() == self.lut_to_lookups.len());
-            self.luts.len() - 1
+    /// Adds a table to the vector of LUTs in the circuit builder, given a list of inputs and table values.
+    pub fn update_luts_from_table(&mut self, inputs: &[u16], table: &[u16]) -> usize {
+        self.try_update_luts_from_table(inputs, table)
+            .expect("lookup table inputs and outputs must be non-empty and equally long")
+    }
+
+    /// Fallible version of [`Self::update_luts_from_pairs`] for untrusted table inputs.
+    pub fn try_update_luts_from_pairs(
+        &mut self,
+        table: LookupTable,
+    ) -> Result<usize, &'static str> {
+        if table.is_empty() {
+            return Err("lookup table must not be empty");
         }
+        Ok(self.insert_lookup_table(table))
     }
 
     /// Adds a table to the vector of LUTs in the circuit builder.
     pub fn update_luts_from_pairs(&mut self, table: LookupTable) -> usize {
-        // If the LUT `table` is already stored in `self.luts`, return its index. Otherwise, append `table` to `self.luts` and return its index.
-        if let Some(idx) = self.is_stored(table.clone()) {
-            idx
-        } else {
-            self.luts.push(table);
-            self.lut_to_lookups.push(vec![]);
-            assert!(self.luts.len() == self.lut_to_lookups.len());
-            self.luts.len() - 1
-        }
+        self.try_update_luts_from_pairs(table)
+            .expect("lookup table must not be empty")
     }
 
     /// Find an available slot, of the form `(row, op)` for gate `G` using parameters `params`

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -1,7 +1,7 @@
 //! Logic for building plonky2 circuits.
 
 #[cfg(not(feature = "std"))]
-use alloc::{collections::BTreeMap, sync::Arc, vec, vec::Vec};
+use alloc::{collections::BTreeMap, string::String, sync::Arc, vec, vec::Vec};
 use core::cmp::max;
 #[cfg(feature = "std")]
 use std::{collections::BTreeMap, sync::Arc};

--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -30,7 +30,7 @@ use crate::field::types::Field;
 use crate::fri::oracle::PolynomialBatch;
 use crate::fri::structure::{
     FriBatchInfo, FriBatchInfoTarget, FriInstanceInfo, FriInstanceInfoTarget, FriOpeningExpression,
-    FriOracleInfo, FriOracleLayout, FriPolynomialInfo,
+    FriOracleInfo, FriOracleLayout, FriOracleRepresentation, FriPolynomialInfo,
 };
 use crate::fri::FriParams;
 // Re-export CircuitConfig from core
@@ -637,6 +637,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CommonCircuitData<F, D> {
         if self.public_initial_degree_bits != self.fri_params.degree_bits {
             return Err("public_initial_degree_bits must match FRI degree_bits");
         }
+        self.check_fri_oracle_layouts()?;
         self.check_poly_fri_proving_params()?;
 
         // All lookup tables must be non-empty.
@@ -646,6 +647,68 @@ impl<F: RichField + Extendable<D>, const D: usize> CommonCircuitData<F, D> {
 
         check_gate_id_collisions(&self.gates)?;
 
+        Ok(())
+    }
+
+    fn checked_layout_poly_count(
+        lhs: usize,
+        rhs: usize,
+        err: &'static str,
+    ) -> Result<usize, &'static str> {
+        lhs.checked_mul(rhs).ok_or(err)
+    }
+
+    fn check_oracle_layout(
+        &self,
+        oracle: PlonkOracle,
+        expected_polys: usize,
+    ) -> Result<(), &'static str> {
+        let layout = self
+            .fri_oracle_layouts
+            .get(oracle.index)
+            .ok_or("missing FRI oracle layout")?;
+        if layout.raw_polys != expected_polys || layout.logical_polys != expected_polys {
+            return Err("FRI oracle layout polynomial count mismatch");
+        }
+        if !matches!(layout.representation, FriOracleRepresentation::Raw) {
+            return Err("unsupported public FRI oracle representation");
+        }
+        Ok(())
+    }
+
+    fn check_fri_oracle_layouts(&self) -> Result<(), &'static str> {
+        let required_len = PlonkOracle::QUOTIENT
+            .index
+            .checked_add(1)
+            .ok_or("FRI oracle layout index overflow")?;
+        if self.fri_oracle_layouts.len() < required_len {
+            return Err("missing FRI oracle layouts");
+        }
+
+        let constants_sigmas = self
+            .num_constants
+            .checked_add(self.config.num_routed_wires)
+            .ok_or("constants/sigmas layout overflow")?;
+        let zs_lookup_per_challenge = self
+            .num_partial_products
+            .checked_add(1)
+            .and_then(|count| count.checked_add(self.num_lookup_polys))
+            .ok_or("zs/lookup layout overflow")?;
+        let zs_lookup = Self::checked_layout_poly_count(
+            self.config.num_challenges,
+            zs_lookup_per_challenge,
+            "zs/lookup layout overflow",
+        )?;
+        let quotient = Self::checked_layout_poly_count(
+            self.config.num_challenges,
+            self.quotient_degree_factor,
+            "quotient layout overflow",
+        )?;
+
+        self.check_oracle_layout(PlonkOracle::CONSTANTS_SIGMAS, constants_sigmas)?;
+        self.check_oracle_layout(PlonkOracle::WIRES, self.config.num_wires)?;
+        self.check_oracle_layout(PlonkOracle::ZS_PARTIAL_PRODUCTS, zs_lookup)?;
+        self.check_oracle_layout(PlonkOracle::QUOTIENT, quotient)?;
         Ok(())
     }
 

--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -645,6 +645,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CommonCircuitData<F, D> {
             return Err("lookup table is empty");
         }
 
+        self.check_gate_shapes()?;
         check_gate_id_collisions(&self.gates)?;
 
         Ok(())
@@ -709,6 +710,35 @@ impl<F: RichField + Extendable<D>, const D: usize> CommonCircuitData<F, D> {
         self.check_oracle_layout(PlonkOracle::WIRES, self.config.num_wires)?;
         self.check_oracle_layout(PlonkOracle::ZS_PARTIAL_PRODUCTS, zs_lookup)?;
         self.check_oracle_layout(PlonkOracle::QUOTIENT, quotient)?;
+        Ok(())
+    }
+
+    fn check_gate_shapes(&self) -> Result<(), &'static str> {
+        for gate in &self.gates {
+            let num_wires = gate.0.num_wires();
+            if num_wires > self.config.num_wires {
+                return Err("gate uses more wires than the circuit config provides");
+            }
+
+            let num_constants = gate.0.num_constants();
+            if num_constants > self.config.num_constants {
+                return Err("gate uses more constants than the circuit config provides");
+            }
+
+            let num_constraints = gate.0.num_constraints();
+            if num_constraints > self.num_gate_constraints {
+                return Err("gate constraint count exceeds common metadata");
+            }
+
+            for (constant_index, wire_index) in gate.0.extra_constant_wires() {
+                if constant_index >= self.config.num_constants {
+                    return Err("gate extra constant index exceeds circuit constants");
+                }
+                if wire_index >= self.config.num_routed_wires {
+                    return Err("gate extra constant wire exceeds routed wires");
+                }
+            }
+        }
         Ok(())
     }
 

--- a/plonky2/src/plonk/config.rs
+++ b/plonky2/src/plonk/config.rs
@@ -7,6 +7,8 @@
 //! mixing Poseidon internally and truncated Keccak externally.
 
 // Re-export core config types - these are the canonical definitions
+use alloc::vec::Vec;
+
 pub use qp_plonky2_core::config::{
     merkle_node_hash_input, GenericConfig, GenericHashOut, Hasher, KeccakGoldilocksConfig,
     PoseidonGoldilocksConfig, MERKLE_LEAF_DOMAIN_TAG, MERKLE_NODE_DOMAIN_TAG,

--- a/plonky2/src/plonk/config.rs
+++ b/plonky2/src/plonk/config.rs
@@ -33,6 +33,16 @@ pub trait AlgebraicHasher<F: RichField>: Hasher<F, Hash = HashOut<F>> {
     where
         F: RichField + Extendable<D>;
 
+    fn hash_no_pad_circuit<const D: usize>(
+        builder: &mut CircuitBuilder<F, D>,
+        inputs: Vec<Target>,
+    ) -> HashOutTarget
+    where
+        F: RichField + Extendable<D>,
+    {
+        HashOutTarget::from_vec(builder.hash_n_to_m_no_pad::<Self>(inputs, NUM_HASH_OUT_ELTS))
+    }
+
     fn hash_merkle_leaf_circuit<const D: usize>(
         builder: &mut CircuitBuilder<F, D>,
         leaf_data: Vec<Target>,

--- a/plonky2/src/plonk/config.rs
+++ b/plonky2/src/plonk/config.rs
@@ -7,6 +7,7 @@
 //! mixing Poseidon internally and truncated Keccak externally.
 
 // Re-export core config types - these are the canonical definitions
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 pub use qp_plonky2_core::config::{

--- a/plonky2/src/plonk/get_challenges.rs
+++ b/plonky2/src/plonk/get_challenges.rs
@@ -199,7 +199,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         &self,
         challenges: &ProofChallenges<F, D>,
         common_data: &CommonCircuitData<F, D>,
-    ) -> FriInferredElements<F, D> {
+    ) -> anyhow::Result<FriInferredElements<F, D>> {
         let ProofChallenges {
             plonk_zeta,
             fri_challenges:
@@ -211,6 +211,32 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
                 },
             ..
         } = challenges;
+        let query_round_proofs = &self.proof.opening_proof.query_round_proofs;
+        let fri_instance = common_data.get_fri_instance(*plonk_zeta);
+        anyhow::ensure!(
+            !fri_query_indices.is_empty(),
+            "compressed FRI proof has no query indices"
+        );
+        anyhow::ensure!(
+            query_round_proofs.indices.len() == fri_query_indices.len()
+                && query_round_proofs
+                    .indices
+                    .iter()
+                    .zip(fri_query_indices)
+                    .all(|(stored, challenge)| stored == challenge),
+            "compressed FRI query indices do not match inferred challenge indices"
+        );
+        anyhow::ensure!(
+            query_round_proofs.steps.len() == common_data.fri_params.reduction_arity_bits.len(),
+            "compressed FRI step count does not match FRI reductions"
+        );
+        if let Some(batch_mask_proof) = &self.proof.opening_proof.batch_mask_proof {
+            anyhow::ensure!(
+                batch_mask_proof.query_openings.len() == fri_query_indices.len(),
+                "compressed FRI batch-mask opening count does not match query count"
+            );
+        }
+
         let mut fri_inferred_elements = Vec::new();
         // Holds the indices that have already been seen at each reduction depth.
         let mut seen_indices_by_depth =
@@ -226,13 +252,17 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         for (query_round_index, &(mut x_index)) in fri_query_indices.iter().enumerate() {
             let mut subgroup_x = F::MULTIPLICATIVE_GROUP_GENERATOR
                 * F::primitive_root_of_unity(log_n).exp_u64(reverse_bits(x_index, log_n) as u64);
+            let initial_trees_proof = query_round_proofs
+                .initial_trees_proofs
+                .get(&x_index)
+                .ok_or_else(|| anyhow::anyhow!("compressed FRI initial tree proof missing"))?;
+            anyhow::ensure!(
+                initial_trees_proof.evals_proofs.len() == fri_instance.oracles.len(),
+                "compressed FRI initial tree proof oracle count mismatch"
+            );
             let expected_unmasked_final = fri_combine_initial::<F, C, D>(
-                &common_data.get_fri_instance(*plonk_zeta),
-                &self
-                    .proof
-                    .opening_proof
-                    .query_round_proofs
-                    .initial_trees_proofs[&x_index],
+                &fri_instance,
+                initial_trees_proof,
                 *fri_alpha,
                 subgroup_x,
                 &precomputed_reduced_evals,
@@ -244,8 +274,12 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
                     .batch_mask_proof
                     .as_ref()
                     .map(|batch_mask_proof| {
+                        let query_opening = batch_mask_proof
+                            .query_openings
+                            .get(query_round_index)
+                            .expect("batch-mask opening count checked above");
                         eval_batch_mask_at_query_point(
-                            &batch_mask_proof.query_openings[query_round_index],
+                            query_opening,
                             subgroup_x.into(),
                             &common_data.fri_params,
                         )
@@ -265,9 +299,14 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
                 }
                 fri_inferred_elements.push(old_eval);
                 let arity = 1 << arity_bits;
-                let mut evals = self.proof.opening_proof.query_round_proofs.steps[i][&coset_index]
-                    .evals
-                    .clone();
+                let step = query_round_proofs.steps[i]
+                    .get(&coset_index)
+                    .ok_or_else(|| anyhow::anyhow!("compressed FRI step proof missing"))?;
+                anyhow::ensure!(
+                    step.evals.len() + 1 == arity,
+                    "compressed FRI step eval count does not match arity"
+                );
+                let mut evals = step.evals.clone();
                 let x_index_within_coset = x_index & (arity - 1);
                 evals.insert(x_index_within_coset, old_eval);
                 old_eval = compute_evaluation(
@@ -275,13 +314,15 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
                     x_index_within_coset,
                     arity_bits,
                     &evals,
-                    fri_betas[i],
+                    *fri_betas
+                        .get(i)
+                        .ok_or_else(|| anyhow::anyhow!("compressed FRI beta missing"))?,
                 );
                 subgroup_x = subgroup_x.exp_power_of_2(arity_bits);
                 x_index = coset_index;
             }
         }
-        FriInferredElements(fri_inferred_elements)
+        Ok(FriInferredElements(fri_inferred_elements))
     }
 }
 

--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -191,7 +191,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     ) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
         let challenges =
             self.get_challenges(self.get_public_inputs_hash(), circuit_digest, common_data)?;
-        let fri_inferred_elements = self.get_inferred_elements(&challenges, common_data);
+        let fri_inferred_elements = self.get_inferred_elements(&challenges, common_data)?;
         let decompressed_proof =
             self.proof
                 .decompress(&challenges, fri_inferred_elements, &common_data.fri_params);
@@ -216,7 +216,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
             &verifier_data.circuit_digest,
             common_data,
         )?;
-        let fri_inferred_elements = self.get_inferred_elements(&challenges, common_data);
+        let fri_inferred_elements = self.get_inferred_elements(&challenges, common_data)?;
         let decompressed_proof =
             self.proof
                 .decompress(&challenges, fri_inferred_elements, &common_data.fri_params);

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -2017,6 +2017,28 @@ fn poseidon2_branch_direction_direct_permutation() -> anyhow::Result<()> {
 }
 
 #[test]
+fn poseidon2_generic_hash_matches_native() -> anyhow::Result<()> {
+    let inputs: Vec<_> = (0..17).map(|i| F::from_canonical_u64(100 + i)).collect();
+    let expected = Poseidon2Hash::hash_no_pad(&inputs);
+
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let input_targets = builder.add_virtual_targets(inputs.len());
+    let digest = builder.hash_n_to_hash_no_pad::<Poseidon2Hash>(input_targets.clone());
+    builder.register_public_inputs(&digest.elements);
+
+    let data = builder.build::<C>();
+    let mut pw = PartialWitness::new();
+    for (&target, &value) in input_targets.iter().zip(&inputs) {
+        pw.set_target(target, value)?;
+    }
+
+    let proof = data.prove(pw)?;
+    assert_eq!(proof.public_inputs, expected.elements.to_vec());
+    data.verify(proof)
+}
+
+#[test]
 fn poseidon2_merkle_recursive_matches_native() -> anyhow::Result<()> {
     let (leaves, tree) = poseidon2_two_leaf_tree();
     let leaf_index = 1;

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -52,6 +52,7 @@ use plonky2::plonk::circuit_data::{
     CircuitConfig, CommonCircuitData, ProverOnlyCircuitData, VerifierCircuitTarget,
 };
 use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher, PoseidonGoldilocksConfig};
+use plonky2::plonk::plonk_common::PlonkOracle;
 use plonky2::plonk::proof::{OpeningSetTarget, ProofTarget, ProofWithPublicInputsTarget};
 use plonky2::plonk::prover::prove;
 use plonky2::plonk::vars::{EvaluationTargets, EvaluationVars};
@@ -898,6 +899,30 @@ fn malformed_verifier_metadata_rejected() {
 
     assert!(common.check_valid().is_err());
     let bytes = common.to_bytes(&serializer).unwrap();
+    assert!(CommonCircuitData::<F, D>::from_bytes(bytes, &serializer).is_err());
+
+    data.common.check_valid().unwrap();
+    let bytes = data.common.to_bytes(&serializer).unwrap();
+    assert!(CommonCircuitData::<F, D>::from_bytes(bytes, &serializer).is_ok());
+}
+
+#[test]
+fn unvalidated_circuit_metadata_rejected() {
+    let data = simple_circuit_data();
+    let serializer = DefaultGateSerializer;
+
+    let mut short_layouts = data.common.clone();
+    short_layouts
+        .fri_oracle_layouts
+        .truncate(PlonkOracle::QUOTIENT.index);
+    assert!(short_layouts.check_valid().is_err());
+    let bytes = short_layouts.to_bytes(&serializer).unwrap();
+    assert!(CommonCircuitData::<F, D>::from_bytes(bytes, &serializer).is_err());
+
+    let mut wrong_wire_count = data.common.clone();
+    wrong_wire_count.fri_oracle_layouts[PlonkOracle::WIRES.index].logical_polys += 1;
+    assert!(wrong_wire_count.check_valid().is_err());
+    let bytes = wrong_wire_count.to_bytes(&serializer).unwrap();
     assert!(CommonCircuitData::<F, D>::from_bytes(bytes, &serializer).is_err());
 
     data.common.check_valid().unwrap();

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -23,6 +23,7 @@ use plonky2::fri::{
     validate_batch_fri_auxiliary_shape, validate_fri_auxiliary_shape, FriBatchMaskingParams,
     FriChallenger, FriConfig, FriFinalPolyLayout, FriParams, FriReductionStrategy,
 };
+use plonky2::gates::arithmetic_base::ArithmeticGate;
 use plonky2::gates::arithmetic_extension::ArithmeticExtensionGate;
 use plonky2::gates::coset_interpolation::CosetInterpolationGate;
 use plonky2::gates::exponentiation::ExponentiationGate;
@@ -1773,6 +1774,23 @@ fn gate_id_collision_common_data_rejected() {
     ];
 
     assert!(common_data.check_valid().is_err());
+}
+
+#[test]
+fn malformed_gate_metadata_rejected() {
+    let data = simple_circuit_data();
+    let serializer = DefaultGateSerializer;
+    let mut common = data.common.clone();
+    let malformed_num_ops = common.config.num_wires / 4 + 1;
+    common.gates = vec![GateRef::new(ArithmeticGate {
+        num_ops: malformed_num_ops,
+    })];
+
+    assert!(common.check_valid().is_err());
+    let bytes = common.to_bytes(&serializer).unwrap();
+    assert!(CommonCircuitData::<F, D>::from_bytes(bytes, &serializer).is_err());
+
+    data.common.check_valid().unwrap();
 }
 
 #[test]

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -418,6 +418,23 @@ fn verifier_cap_height_mismatch_returns_err() -> anyhow::Result<()> {
 }
 
 #[test]
+fn malformed_merkle_caps_rejected() {
+    let digest = PoseidonHash::hash_merkle_leaf(&[F::ZERO]);
+    let empty = MerkleCap::<F, PoseidonHash>(vec![]);
+    let wrong_height = MerkleCap::<F, PoseidonHash>(vec![digest]);
+    let non_power_of_two = MerkleCap::<F, PoseidonHash>(vec![digest, digest, digest]);
+    let valid = MerkleCap::<F, PoseidonHash>(vec![digest, digest]);
+
+    assert!(qp_plonky2_core::validate_merkle_cap_height(&empty, 0, "test cap").is_err());
+    assert!(qp_plonky2_core::validate_merkle_cap_height(&wrong_height, 1, "test cap").is_err());
+    assert!(
+        qp_plonky2_core::validate_merkle_cap_power_of_two(&non_power_of_two, "test cap").is_err()
+    );
+    qp_plonky2_core::validate_merkle_cap_height(&valid, 1, "test cap").unwrap();
+    qp_plonky2_core::validate_merkle_cap_power_of_two(&valid, "test cap").unwrap();
+}
+
+#[test]
 fn malformed_fft_root_table_rejected() {
     let mut data = simple_circuit_data();
     data.prover_only.fft_root_table = Some(vec![vec![F::ONE]]);

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -904,6 +904,74 @@ fn malformed_verifier_metadata_rejected() {
 }
 
 #[test]
+fn malformed_compressed_proofs_return_err() -> anyhow::Result<()> {
+    let mut config = CircuitConfig::standard_recursion_config();
+    config.fri_config.reduction_strategy = FriReductionStrategy::Fixed(vec![1, 1]);
+    config.fri_config.num_query_rounds = 50;
+
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let x = builder.constant(F::from_canonical_u64(3));
+    let y = builder.constant(F::from_canonical_u64(5));
+    let product = builder.mul(x, y);
+    let expected = builder.constant(F::from_canonical_u64(15));
+    builder.connect(product, expected);
+    for _ in 0..100 {
+        builder.add_gate(NoopGate, vec![]);
+    }
+    let data = builder.build::<C>();
+    let proof = data.prove(PartialWitness::new())?;
+    let compressed = data.compress(proof)?;
+
+    data.verify_compressed(compressed.clone())?;
+    assert!(!compressed
+        .proof
+        .opening_proof
+        .query_round_proofs
+        .steps
+        .is_empty());
+
+    let mut missing_initial = compressed.clone();
+    missing_initial
+        .proof
+        .opening_proof
+        .query_round_proofs
+        .initial_trees_proofs
+        .clear();
+    let result = catch_unwind(AssertUnwindSafe(|| data.verify_compressed(missing_initial)));
+    assert!(
+        result.is_ok(),
+        "missing compressed initial proof must not panic"
+    );
+    assert!(result.unwrap().is_err());
+
+    let mut missing_step = compressed.clone();
+    missing_step.proof.opening_proof.query_round_proofs.steps[0].clear();
+    let result = catch_unwind(AssertUnwindSafe(|| data.verify_compressed(missing_step)));
+    assert!(
+        result.is_ok(),
+        "missing compressed step proof must not panic"
+    );
+    assert!(result.unwrap().is_err());
+
+    let mut mismatched_indices = compressed;
+    mismatched_indices
+        .proof
+        .opening_proof
+        .query_round_proofs
+        .indices[0] ^= 1;
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        data.verify_compressed(mismatched_indices)
+    }));
+    assert!(
+        result.is_ok(),
+        "mismatched compressed query indices must not panic"
+    );
+    assert!(result.unwrap().is_err());
+
+    Ok(())
+}
+
+#[test]
 fn forged_proving_key_crashes_rejected() -> anyhow::Result<()> {
     let config = CircuitConfig::standard_recursion_polyfri_zk_config();
     let mut builder = CircuitBuilder::<F, D>::new(config);

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -1534,6 +1534,19 @@ fn merkle_poseidon_zero_suffix_leaf_collision_rejected() -> anyhow::Result<()> {
 }
 
 #[test]
+fn short_merkle_leaves_are_length_bound() -> anyhow::Result<()> {
+    let leaf = vec![F::from_canonical_u64(7)];
+    let leaves = vec![leaf.clone(), vec![F::from_canonical_u64(8)]];
+    let tree = MerkleTree::<F, PoseidonHash>::new(leaves, 0);
+    let proof = tree.prove(0);
+
+    verify_merkle_proof_to_cap(leaf.clone(), 0, &tree.cap, &proof)?;
+    assert!(verify_merkle_proof_to_cap(vec![leaf[0], F::ZERO], 0, &tree.cap, &proof).is_err());
+
+    Ok(())
+}
+
+#[test]
 fn trailing_zero_hash_len_delimited_distinguishes_lengths() {
     type P = <PoseidonHash as Hasher<F>>::Permutation;
 

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -15,11 +15,11 @@ use plonky2::fri::proof::{
     FriChallenges, FriFinalPolys, FriFinalPolysTarget, FriInitialTreeProof, FriProof,
     FriProofTarget, FriQueryRound,
 };
+use plonky2::fri::structure::{
+    FriBatchInfo, FriInstanceInfo, FriOpeningBatch, FriOpeningExpression, FriOpenings,
+    FriOracleInfo, FriPolynomialInfo,
+};
 use plonky2::fri::{
-    structure::{
-        FriBatchInfo, FriInstanceInfo, FriOpeningBatch, FriOpeningExpression, FriOpenings,
-        FriOracleInfo, FriPolynomialInfo,
-    },
     validate_batch_fri_auxiliary_shape, validate_fri_auxiliary_shape, FriBatchMaskingParams,
     FriChallenger, FriConfig, FriFinalPolyLayout, FriParams, FriReductionStrategy,
 };

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -1586,6 +1586,38 @@ fn lookup_deserializers_reject_unvalidated_indices() -> anyhow::Result<()> {
 }
 
 #[test]
+fn empty_lookup_tables_rejected() {
+    fn identity_u16(x: u16) -> u16 {
+        x
+    }
+
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+
+    assert!(builder
+        .try_add_lookup_table_from_pairs(std::sync::Arc::new(vec![]))
+        .is_err());
+    assert!(builder.try_add_lookup_table_from_table(&[], &[]).is_err());
+    assert!(builder
+        .try_add_lookup_table_from_fn(identity_u16, &[])
+        .is_err());
+
+    let table_index = builder
+        .try_add_lookup_table_from_pairs(std::sync::Arc::new(vec![(0u16, 1u16)]))
+        .unwrap();
+    assert_eq!(table_index, 0);
+
+    let data = simple_circuit_data();
+    let serializer = DefaultGateSerializer;
+    let mut common = data.common.clone();
+    common.luts = vec![std::sync::Arc::new(vec![])];
+
+    assert!(common.check_valid().is_err());
+    let bytes = common.to_bytes(&serializer).unwrap();
+    assert!(CommonCircuitData::<F, D>::from_bytes(bytes, &serializer).is_err());
+}
+
+#[test]
 fn merkle_poseidon_zero_suffix_leaf_collision_rejected() -> anyhow::Result<()> {
     let leaf = vec![
         F::from_canonical_u64(1),

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -28,6 +28,7 @@ use plonky2::gates::arithmetic_extension::ArithmeticExtensionGate;
 use plonky2::gates::coset_interpolation::CosetInterpolationGate;
 use plonky2::gates::exponentiation::ExponentiationGate;
 use plonky2::gates::gate::{Gate, GateRef};
+use plonky2::gates::lookup::{LookupGate, LookupGenerator};
 use plonky2::gates::multiplication_extension::MulExtensionGate;
 use plonky2::gates::noop::NoopGate;
 use plonky2::gates::poseidon2::SPONGE_WIDTH;
@@ -45,7 +46,7 @@ use plonky2::hash::poseidon::PoseidonHash;
 use plonky2::hash::poseidon2::{Poseidon2Hash, Poseidon2Permutation};
 use plonky2::iop::challenger::Challenger;
 use plonky2::iop::ext_target::ExtensionTarget;
-use plonky2::iop::generator::WitnessGeneratorRef;
+use plonky2::iop::generator::{SimpleGenerator, WitnessGeneratorRef};
 use plonky2::iop::target::Target;
 use plonky2::iop::witness::{PartialWitness, Witness, WitnessWrite};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
@@ -1535,6 +1536,51 @@ fn zero_slot_generator_rejected() -> anyhow::Result<()> {
     let mut narrow_lookup = CircuitConfig::standard_recursion_config();
     narrow_lookup.num_routed_wires = 2;
     assert!(narrow_lookup.check_lookup_widths().is_err());
+
+    Ok(())
+}
+
+#[test]
+fn lookup_deserializers_reject_unvalidated_indices() -> anyhow::Result<()> {
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let input = builder.add_virtual_target();
+    let table = std::sync::Arc::new(vec![(0u16, 10u16), (1u16, 11u16)]);
+    let table_index = builder.add_lookup_table_from_pairs(table);
+    let output = builder.add_lookup_from_index(input, table_index);
+    builder.register_public_input(output);
+
+    let data = builder.build::<C>();
+    let lut_count = data.common.luts.len();
+    let lookup_slots = data.common.config.num_routed_wires / 2;
+
+    let mut gate_bytes = Vec::new();
+    gate_bytes.write_usize(lookup_slots).unwrap();
+    gate_bytes.write_usize(lut_count).unwrap();
+    gate_bytes.extend_from_slice(&[0u8; 32]);
+    let mut gate_buffer = Buffer::new(&gate_bytes);
+    assert!(<LookupGate as Gate<F, D>>::deserialize(&mut gate_buffer, &data.common).is_err());
+
+    let mut generator_bytes = Vec::new();
+    generator_bytes.write_usize(0).unwrap();
+    generator_bytes.write_usize(0).unwrap();
+    generator_bytes.write_usize(lut_count).unwrap();
+    let mut generator_buffer = Buffer::new(&generator_bytes);
+    assert!(<LookupGenerator as SimpleGenerator<F, D>>::deserialize(
+        &mut generator_buffer,
+        &data.common
+    )
+    .is_err());
+
+    let mut row_bytes = Vec::new();
+    row_bytes.write_usize(data.common.degree()).unwrap();
+    row_bytes.write_usize(0).unwrap();
+    row_bytes.write_usize(0).unwrap();
+    let mut row_buffer = Buffer::new(&row_bytes);
+    assert!(
+        <LookupGenerator as SimpleGenerator<F, D>>::deserialize(&mut row_buffer, &data.common)
+            .is_err()
+    );
 
     Ok(())
 }

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -29,17 +29,19 @@ use plonky2::gates::exponentiation::ExponentiationGate;
 use plonky2::gates::gate::{Gate, GateRef};
 use plonky2::gates::multiplication_extension::MulExtensionGate;
 use plonky2::gates::noop::NoopGate;
+use plonky2::gates::poseidon2::SPONGE_WIDTH;
 use plonky2::gates::reducing::ReducingGate;
 use plonky2::gates::reducing_extension::ReducingExtensionGate;
 use plonky2::gates::util::StridedConstraintConsumer;
 use plonky2::hash::batch_merkle_tree::BatchMerkleTree;
-use plonky2::hash::hashing::{hash_n_to_hash_len_delimited, hash_n_to_m_no_pad};
+use plonky2::hash::hash_types::{HashOut, NUM_HASH_OUT_ELTS};
+use plonky2::hash::hashing::{hash_n_to_hash_len_delimited, hash_n_to_m_no_pad, PlonkyPermutation};
 use plonky2::hash::merkle_proofs::{
     verify_batch_merkle_proof_to_cap, verify_merkle_proof_to_cap, MerkleProof, MerkleProofTarget,
 };
 use plonky2::hash::merkle_tree::{MerkleCap, MerkleTree};
 use plonky2::hash::poseidon::PoseidonHash;
-use plonky2::hash::poseidon2::Poseidon2Hash;
+use plonky2::hash::poseidon2::{Poseidon2Hash, Poseidon2Permutation};
 use plonky2::iop::challenger::Challenger;
 use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::iop::generator::WitnessGeneratorRef;
@@ -49,7 +51,7 @@ use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::circuit_data::{
     CircuitConfig, CommonCircuitData, ProverOnlyCircuitData, VerifierCircuitTarget,
 };
-use plonky2::plonk::config::{GenericConfig, Hasher, PoseidonGoldilocksConfig};
+use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher, PoseidonGoldilocksConfig};
 use plonky2::plonk::proof::{OpeningSetTarget, ProofTarget, ProofWithPublicInputsTarget};
 use plonky2::plonk::prover::prove;
 use plonky2::plonk::vars::{EvaluationTargets, EvaluationVars};
@@ -1963,6 +1965,55 @@ fn poseidon2_merkle_valid_proof_verifies() -> anyhow::Result<()> {
     let proof = tree.prove(1);
 
     verify_merkle_proof_to_cap(leaves[1].clone(), 1, &tree.cap, &proof)
+}
+
+fn poseidon2_direct_permutation_digest(left: HashOut<F>, right: HashOut<F>) -> HashOut<F> {
+    let mut inputs = Vec::with_capacity(SPONGE_WIDTH);
+    inputs.extend_from_slice(&left.elements);
+    inputs.extend_from_slice(&right.elements);
+    inputs.resize(SPONGE_WIDTH, F::ZERO);
+    let mut permutation = Poseidon2Permutation::<F>::new(inputs);
+    permutation.permute();
+    HashOut::from_vec(permutation.squeeze()[..NUM_HASH_OUT_ELTS].to_vec())
+}
+
+#[test]
+fn poseidon2_branch_direction_direct_permutation() -> anyhow::Result<()> {
+    let left = Poseidon2Hash::hash_merkle_leaf(&[F::from_canonical_u64(3)]);
+    let right = Poseidon2Hash::hash_merkle_leaf(&[F::from_canonical_u64(5)]);
+    let unswapped = poseidon2_direct_permutation_digest(left, right);
+    let swapped = poseidon2_direct_permutation_digest(right, left);
+    assert_ne!(unswapped, swapped);
+
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+
+    let mut inputs = Vec::with_capacity(SPONGE_WIDTH);
+    inputs.extend_from_slice(&left.elements);
+    inputs.extend_from_slice(&right.elements);
+    inputs.resize(SPONGE_WIDTH, F::ZERO);
+    let input_targets = builder.constants(&inputs);
+
+    let false_swap = builder.constant_bool(false);
+    let true_swap = builder.constant_bool(true);
+    let out_unswapped = Poseidon2Hash::permute_swapped::<D>(
+        Poseidon2Permutation::<Target>::new(input_targets.clone()),
+        false_swap,
+        &mut builder,
+    );
+    let out_swapped = Poseidon2Hash::permute_swapped::<D>(
+        Poseidon2Permutation::<Target>::new(input_targets),
+        true_swap,
+        &mut builder,
+    );
+    builder.register_public_inputs(&out_unswapped.as_ref()[..NUM_HASH_OUT_ELTS]);
+    builder.register_public_inputs(&out_swapped.as_ref()[..NUM_HASH_OUT_ELTS]);
+
+    let data = builder.build::<C>();
+    let proof = data.prove(PartialWitness::new())?;
+    let expected = [unswapped.elements.to_vec(), swapped.elements.to_vec()].concat();
+    assert_eq!(proof.public_inputs, expected);
+    data.verify(proof)
 }
 
 #[test]

--- a/verifier/src/gates/reducing.rs
+++ b/verifier/src/gates/reducing.rs
@@ -2,6 +2,8 @@
 use alloc::{format, string::String, vec::Vec};
 use core::ops::Range;
 
+use qp_plonky2_core::circuit_config::reducing_base_capacity;
+
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::gates::gate::VerificationGate;
 use crate::gates::util::StridedConstraintConsumer;
@@ -9,7 +11,6 @@ use crate::hash::hash_types::RichField;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::vars::{EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::{Buffer, IoResult, Read, Write};
-use qp_plonky2_core::circuit_config::reducing_base_capacity;
 
 /// Computes `sum alpha^i c_i` for a vector `c_i` of `num_coeffs` elements of the base field.
 #[derive(Debug, Default, Clone)]

--- a/verifier/src/gates/reducing_extension.rs
+++ b/verifier/src/gates/reducing_extension.rs
@@ -2,6 +2,8 @@
 use alloc::{format, string::String, vec::Vec};
 use core::ops::Range;
 
+use qp_plonky2_core::circuit_config::reducing_extension_capacity;
+
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::gates::gate::VerificationGate;
 use crate::gates::util::StridedConstraintConsumer;
@@ -9,7 +11,6 @@ use crate::hash::hash_types::RichField;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::vars::{EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::{Buffer, IoResult, Read, Write};
-use qp_plonky2_core::circuit_config::reducing_extension_capacity;
 
 /// Computes `sum alpha^i c_i` for a vector `c_i` of `num_coeffs` elements of the extension field.
 #[derive(Debug, Clone, Default)]

--- a/verifier/src/plonk/circuit_data.rs
+++ b/verifier/src/plonk/circuit_data.rs
@@ -280,6 +280,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CommonVerifierData<F, D> {
             return Err("lookup table is empty");
         }
 
+        self.check_gate_shapes()?;
         check_gate_id_collisions(&self.gates)?;
 
         Ok(())
@@ -344,6 +345,35 @@ impl<F: RichField + Extendable<D>, const D: usize> CommonVerifierData<F, D> {
         self.check_oracle_layout(PlonkOracle::WIRES, self.config.num_wires)?;
         self.check_oracle_layout(PlonkOracle::ZS_PARTIAL_PRODUCTS, zs_lookup)?;
         self.check_oracle_layout(PlonkOracle::QUOTIENT, quotient)?;
+        Ok(())
+    }
+
+    fn check_gate_shapes(&self) -> Result<(), &'static str> {
+        for gate in &self.gates {
+            let num_wires = gate.0.num_wires();
+            if num_wires > self.config.num_wires {
+                return Err("gate uses more wires than the circuit config provides");
+            }
+
+            let num_constants = gate.0.num_constants();
+            if num_constants > self.config.num_constants {
+                return Err("gate uses more constants than the circuit config provides");
+            }
+
+            let num_constraints = gate.0.num_constraints();
+            if num_constraints > self.num_gate_constraints {
+                return Err("gate constraint count exceeds common metadata");
+            }
+
+            for (constant_index, wire_index) in gate.0.extra_constant_wires() {
+                if constant_index >= self.config.num_constants {
+                    return Err("gate extra constant index exceeds circuit constants");
+                }
+                if wire_index >= self.config.num_routed_wires {
+                    return Err("gate extra constant wire exceeds routed wires");
+                }
+            }
+        }
         Ok(())
     }
 

--- a/verifier/src/plonk/circuit_data.rs
+++ b/verifier/src/plonk/circuit_data.rs
@@ -17,7 +17,7 @@ use crate::field::extension::Extendable;
 use crate::field::types::Field;
 use crate::fri::structure::{
     FriBatchInfo, FriInstanceInfo, FriOpeningExpression, FriOracleInfo, FriOracleLayout,
-    FriPolynomialInfo,
+    FriOracleRepresentation, FriPolynomialInfo,
 };
 use crate::gates::gate::{check_gate_id_collisions, GateRef};
 use crate::gates::lookup_table::LookupTable;
@@ -273,6 +273,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CommonVerifierData<F, D> {
         if self.public_initial_degree_bits != self.fri_params.degree_bits {
             return Err("public_initial_degree_bits must match FRI degree_bits");
         }
+        self.check_fri_oracle_layouts()?;
 
         // All lookup tables must be non-empty.
         if self.luts.iter().any(|lut| lut.is_empty()) {
@@ -281,6 +282,68 @@ impl<F: RichField + Extendable<D>, const D: usize> CommonVerifierData<F, D> {
 
         check_gate_id_collisions(&self.gates)?;
 
+        Ok(())
+    }
+
+    fn checked_layout_poly_count(
+        lhs: usize,
+        rhs: usize,
+        err: &'static str,
+    ) -> Result<usize, &'static str> {
+        lhs.checked_mul(rhs).ok_or(err)
+    }
+
+    fn check_oracle_layout(
+        &self,
+        oracle: PlonkOracle,
+        expected_polys: usize,
+    ) -> Result<(), &'static str> {
+        let layout = self
+            .fri_oracle_layouts
+            .get(oracle.index)
+            .ok_or("missing FRI oracle layout")?;
+        if layout.raw_polys != expected_polys || layout.logical_polys != expected_polys {
+            return Err("FRI oracle layout polynomial count mismatch");
+        }
+        if !matches!(layout.representation, FriOracleRepresentation::Raw) {
+            return Err("unsupported public FRI oracle representation");
+        }
+        Ok(())
+    }
+
+    fn check_fri_oracle_layouts(&self) -> Result<(), &'static str> {
+        let required_len = PlonkOracle::QUOTIENT
+            .index
+            .checked_add(1)
+            .ok_or("FRI oracle layout index overflow")?;
+        if self.fri_oracle_layouts.len() < required_len {
+            return Err("missing FRI oracle layouts");
+        }
+
+        let constants_sigmas = self
+            .num_constants
+            .checked_add(self.config.num_routed_wires)
+            .ok_or("constants/sigmas layout overflow")?;
+        let zs_lookup_per_challenge = self
+            .num_partial_products
+            .checked_add(1)
+            .and_then(|count| count.checked_add(self.num_lookup_polys))
+            .ok_or("zs/lookup layout overflow")?;
+        let zs_lookup = Self::checked_layout_poly_count(
+            self.config.num_challenges,
+            zs_lookup_per_challenge,
+            "zs/lookup layout overflow",
+        )?;
+        let quotient = Self::checked_layout_poly_count(
+            self.config.num_challenges,
+            self.quotient_degree_factor,
+            "quotient layout overflow",
+        )?;
+
+        self.check_oracle_layout(PlonkOracle::CONSTANTS_SIGMAS, constants_sigmas)?;
+        self.check_oracle_layout(PlonkOracle::WIRES, self.config.num_wires)?;
+        self.check_oracle_layout(PlonkOracle::ZS_PARTIAL_PRODUCTS, zs_lookup)?;
+        self.check_oracle_layout(PlonkOracle::QUOTIENT, quotient)?;
         Ok(())
     }
 

--- a/verifier/src/plonk/get_challenges.rs
+++ b/verifier/src/plonk/get_challenges.rs
@@ -193,7 +193,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         &self,
         challenges: &ProofChallenges<F, D>,
         common_data: &CommonCircuitData<F, D>,
-    ) -> FriInferredElements<F, D> {
+    ) -> anyhow::Result<FriInferredElements<F, D>> {
         let ProofChallenges {
             plonk_zeta,
             fri_challenges:
@@ -205,6 +205,32 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
                 },
             ..
         } = challenges;
+        let query_round_proofs = &self.proof.opening_proof.query_round_proofs;
+        let fri_instance = common_data.get_fri_instance(*plonk_zeta);
+        anyhow::ensure!(
+            !fri_query_indices.is_empty(),
+            "compressed FRI proof has no query indices"
+        );
+        anyhow::ensure!(
+            query_round_proofs.indices.len() == fri_query_indices.len()
+                && query_round_proofs
+                    .indices
+                    .iter()
+                    .zip(fri_query_indices)
+                    .all(|(stored, challenge)| stored == challenge),
+            "compressed FRI query indices do not match inferred challenge indices"
+        );
+        anyhow::ensure!(
+            query_round_proofs.steps.len() == common_data.fri_params.reduction_arity_bits.len(),
+            "compressed FRI step count does not match FRI reductions"
+        );
+        if let Some(batch_mask_proof) = &self.proof.opening_proof.batch_mask_proof {
+            anyhow::ensure!(
+                batch_mask_proof.query_openings.len() == fri_query_indices.len(),
+                "compressed FRI batch-mask opening count does not match query count"
+            );
+        }
+
         let mut fri_inferred_elements = Vec::new();
         // Holds the indices that have already been seen at each reduction depth.
         let mut seen_indices_by_depth =
@@ -220,13 +246,17 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         for (query_round_index, &(mut x_index)) in fri_query_indices.iter().enumerate() {
             let mut subgroup_x = F::MULTIPLICATIVE_GROUP_GENERATOR
                 * F::primitive_root_of_unity(log_n).exp_u64(reverse_bits(x_index, log_n) as u64);
+            let initial_trees_proof = query_round_proofs
+                .initial_trees_proofs
+                .get(&x_index)
+                .ok_or_else(|| anyhow::anyhow!("compressed FRI initial tree proof missing"))?;
+            anyhow::ensure!(
+                initial_trees_proof.evals_proofs.len() == fri_instance.oracles.len(),
+                "compressed FRI initial tree proof oracle count mismatch"
+            );
             let expected_unmasked_final = fri_combine_initial::<F, C, D>(
-                &common_data.get_fri_instance(*plonk_zeta),
-                &self
-                    .proof
-                    .opening_proof
-                    .query_round_proofs
-                    .initial_trees_proofs[&x_index],
+                &fri_instance,
+                initial_trees_proof,
                 *fri_alpha,
                 subgroup_x,
                 &precomputed_reduced_evals,
@@ -238,8 +268,12 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
                     .batch_mask_proof
                     .as_ref()
                     .map(|batch_mask_proof| {
+                        let query_opening = batch_mask_proof
+                            .query_openings
+                            .get(query_round_index)
+                            .expect("batch-mask opening count checked above");
                         eval_batch_mask_at_query_point(
-                            &batch_mask_proof.query_openings[query_round_index],
+                            query_opening,
                             subgroup_x.into(),
                             &common_data.fri_params,
                         )
@@ -259,9 +293,14 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
                 }
                 fri_inferred_elements.push(old_eval);
                 let arity = 1 << arity_bits;
-                let mut evals = self.proof.opening_proof.query_round_proofs.steps[i][&coset_index]
-                    .evals
-                    .clone();
+                let step = query_round_proofs.steps[i]
+                    .get(&coset_index)
+                    .ok_or_else(|| anyhow::anyhow!("compressed FRI step proof missing"))?;
+                anyhow::ensure!(
+                    step.evals.len() + 1 == arity,
+                    "compressed FRI step eval count does not match arity"
+                );
+                let mut evals = step.evals.clone();
                 let x_index_within_coset = x_index & (arity - 1);
                 evals.insert(x_index_within_coset, old_eval);
                 old_eval = compute_evaluation(
@@ -269,12 +308,14 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
                     x_index_within_coset,
                     arity_bits,
                     &evals,
-                    fri_betas[i],
+                    *fri_betas
+                        .get(i)
+                        .ok_or_else(|| anyhow::anyhow!("compressed FRI beta missing"))?,
                 );
                 subgroup_x = subgroup_x.exp_power_of_2(arity_bits);
                 x_index = coset_index;
             }
         }
-        FriInferredElements(fri_inferred_elements)
+        Ok(FriInferredElements(fri_inferred_elements))
     }
 }

--- a/verifier/src/plonk/proof.rs
+++ b/verifier/src/plonk/proof.rs
@@ -175,7 +175,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     ) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
         let challenges =
             self.get_challenges(self.get_public_inputs_hash(), circuit_digest, common_data)?;
-        let fri_inferred_elements = self.get_inferred_elements(&challenges, common_data);
+        let fri_inferred_elements = self.get_inferred_elements(&challenges, common_data)?;
         let decompressed_proof =
             self.proof
                 .decompress(&challenges, fri_inferred_elements, &common_data.fri_params);
@@ -200,7 +200,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
             &verifier_data.circuit_digest,
             common_data,
         )?;
-        let fri_inferred_elements = self.get_inferred_elements(&challenges, common_data);
+        let fri_inferred_elements = self.get_inferred_elements(&challenges, common_data)?;
         let decompressed_proof =
             self.proof
                 .decompress(&challenges, fri_inferred_elements, &common_data.fri_params);


### PR DESCRIPTION
## V12 audit (9/10): medium Merkle binding, compressed-proof & circuit/gate metadata validation

Part of the stack splitting #38 into reviewable slices. Stacked on `v12-audit/08-medium-lookup-interp-subgroup`.

Addresses **9** V12 audit finding(s):

| Finding | Severity | Title | Commit |
|---|---|---|---|
| #64706 | Medium | Malformed Merkle caps can panic proof verification | `c5cd9414` |
| #64707 | Medium | Malformed compressed proofs panic instead of returning errors | `4932fe0e` |
| #64708 | Medium | Short Merkle leaves are not uniquely committed | `86bb5cd5` |
| #64709 | Medium | Poseidon2 recursive Merkle hashing ignores branch direction | `a1bf921e` |
| #64710 | Medium | Generic circuit hashing does not implement Poseidon2 semantics | `23787a21` |
| #64711 | Medium | Unvalidated circuit metadata can panic or hang verification | `b6a40470` |
| #64712 | Medium | Malformed gate metadata can panic circuit loading and verification | `f30021de` |
| #64713 | Medium | Lookup deserializers panic on unvalidated serialized indices | `7b990e4c` |
| #64714 | Medium | Empty lookup tables panic during build and witness generation | `c2c88e97` |

---

<details>
<summary><b>#64706 · Medium · Malformed Merkle caps can panic proof verification</b></summary>

**Targets**
- validate_shape::validate_proof_with_pis_shape
- fri_validate_shape::validate_fri_proof_shape
- util::log2_strict
- CircuitData::verify
- verifier::verify
- MerkleCap::height
- Proof::deserialize
- ProofWithPublicInputs::deserialize

**Affected Locations**
- **validate_shape.validate_proof_with_pis_shape**: PLONK proof-shape validation reaches `MerkleCap::height()` on attacker-controlled caps.
- **fri_validate_shape.validate_fri_proof_shape**: FRI proof-shape validation also calls `height()` on proof-supplied caps.
- **util.log2_strict**: Strict logarithm uses `assert!`, turning malformed cap lengths into panics.
- **CircuitData.verify**: Public verifier entrypoint forwards attacker-controlled proofs into lower-level verification.
- **verifier.verify**: Verifier invokes proof-shape validation and later FRI verification on untrusted proof data.
- **MerkleCap.height**: Cap height calculation forwards untrusted cap lengths into strict logarithm logic.
- **Proof.deserialize**: `Proof` is deserializable and publicly constructible, enabling malformed caps to reach verification.
- **ProofWithPublicInputs.deserialize**: `ProofWithPublicInputs` is deserializable and carries attacker-controlled proof objects into verifier APIs.
- **validate_shape.validate_proof_shape**: Untrusted proof caps are validated by calling `.height()` directly.
- **plonky2_util.log2_strict**: Panics unless the input is an exact power of two.
- **Proof.validate_proof_shape**: Proof fields, including Merkle caps, are public and deserializable.
- **ProofWithPublicInputs.validate_proof_shape**: Wrapper type is also public and deserializable, enabling attacker-controlled malformed proofs.
- **verifier.verify_with_challenges**: Verifier also delegates to FRI verification, which validates proof-controlled caps.
- **verifier.validate_proof_shape**: PLONK proof-shape validation calls `height()` on untrusted Merkle caps.
- **verifier.validate_fri_proof_shape**: FRI proof-shape validation also calls `height()` on proof-supplied caps.
- **Proof.verify**: Public verifier entrypoint forwards untrusted proofs into shape validation.
- **Proof.height**: `MerkleCap::height()` delegates to `log2_strict(self.len())`.
- **Proof.validate_proof_with_pis_shape**: `log2_strict` uses `assert!`, so invalid lengths panic.
- **ProofWithPublicInputs.validate_proof_with_pis_shape**: `ProofWithPublicInputs` is also deserializable and accepted by verifier entrypoints.

**Description**

Proof verification performs shape checks on attacker-controlled Merkle caps by calling `MerkleCap::height()` inside both the PLONK and FRI validation paths. That helper is not fallible: it delegates to `log2_strict(self.len())`, which uses `assert!` and panics when a cap length is `0` or not a power of two. As a result, malformed `wires_cap`, `plonk_zs_partial_products_cap`, `quotient_polys_cap`, or FRI commit-phase and batch-mask caps can crash verification before the code returns `Err`. The issue is reachable from verifier entrypoints because `verify`/`CircuitData::verify` accept attacker-supplied proofs and the proof structs are publicly constructible and `Deserialize`. The needed fix is to treat cap length as untrusted input everywhere it is checked, either by making `height()` fallible or by explicitly rejecting empty and non-power-of-two lengths before any call to `height()`.

**Root cause**

The verifier's shape-validation logic calls panic-based `MerkleCap::height()` on untrusted proof caps instead of using explicit fallible checks for nonzero power-of-two lengths.

**Impact**

An attacker can send a malformed proof object and force the verifier down a panic path without producing a valid proof. In applications that expose verification on untrusted inputs, this can terminate the current request handler, worker, or entire process under `panic=abort`, causing a reliable denial of service.

</details>

<details>
<summary><b>#64707 · Medium · Malformed compressed proofs panic instead of returning errors</b></summary>

**Targets**
- CompressedProofWithPublicInputs::get_inferred_elements
- CompressedFriProof::decompress
- path_compression::decompress_merkle_proofs
- CompressedProofWithPublicInputs::verify
- CompressedProofWithPublicInputs::decompress
- Buffer::read_compressed_fri_query_rounds
- VerifierCircuitData::verify_compressed

**Affected Locations**
- **CompressedProofWithPublicInputs.get_inferred_elements**: Transcript-derived query indices are used to index compressed-proof maps and vectors with `[]` before any structural validation.
- **CompressedFriProof.decompress**: Compressed FRI decompression uses `HashMap` indexing and `unwrap()` while rebuilding query rounds from attacker-influenced state.
- **path_compression.decompress_merkle_proofs**: Malformed compressed Merkle paths hit unchecked map access and sibling `unwrap()` calls during decompression.
- **CompressedProofWithPublicInputs.verify**: Compressed proof verification only checks public-input length before reconstructing inferred elements and decompressing attacker-controlled proof data.
- **CompressedProofWithPublicInputs.decompress**: Public decompression API reaches the same unvalidated compressed-proof reconstruction path.
- **Buffer.read_compressed_fri_query_rounds**: Deserializer accepts attacker-chosen compressed query indices and constructs the internal maps later trusted by verification.
- **VerifierCircuitData.verify_compressed**: Public verifier entrypoint forwards untrusted compressed proofs into the vulnerable path.
- **CompressedProofWithPublicInputs.from_bytes**: Malformed compressed proof objects are reachable from untrusted bytes.
- **verify.verify**: Uncompressed verification explicitly validates proof shape first, highlighting the missing defense in the compressed path.
- **CompressedProofWithPublicInputs.verify_compressed**: Public verifier entrypoint forwards attacker-controlled compressed proofs into the vulnerable path.
- **CompressedProofWithPublicInputs.read_compressed_fri_query_rounds**: Deserializer accepts attacker-chosen original query indices and builds the internal maps from them.
- **CompressedProofWithPublicInputs.read_compressed_proof_with_public_inputs**: Compressed proofs are deserialized directly from untrusted bytes.
- **CircuitData.verify_compressed**: Public APIs exposing the vulnerable compressed-proof verification/decompression flows to downstream callers.
- **CompressedFriQueryRounds.read_compressed_fri_query_rounds**: Compressed proof bytes provide the query indices used as map keys during deserialization.

**Description**

The compressed-proof flow accepts attacker-controlled FRI query data, recomputes Fiat-Shamir `fri_query_indices`, and then immediately calls `get_inferred_elements` and `CompressedFriProof::decompress` before any compressed-proof shape validation occurs. Those helpers assume the serialized maps and vectors are complete, using panic-on-miss operations such as `initial_trees_proofs[&x_index]`, `steps[i][&coset_index]`, `query_openings[query_round_index]`, `.values().next().unwrap()`, `fri_inferred_elements.next().unwrap()`, and the unchecked `decompress_merkle_proofs` path. The deserializer also accepts attacker-chosen compressed query indices and builds the backing `HashMap`s from them verbatim, so a malformed proof can make the stored structure diverge from the transcript-derived indices the verifier later uses. As a result, `verify_compressed`, compressed `verify`, and public `decompress` can panic on malformed input instead of rejecting it with `Err`. The uncompressed verifier already calls `validate_proof_with_pis_shape`, which highlights that the compressed path is missing an equivalent validation step and fallible error handling.

**Root cause**

The compressed-proof pipeline trusts attacker-influenced FRI structure and dereferences it with unchecked indexing and `unwrap()` in `get_inferred_elements`, `CompressedFriProof::decompress`, and Merkle-path decompression instead of validating shape consistency and returning `Result` errors.

**Impact**

An attacker can submit a malformed compressed proof that crashes verification or decompression rather than being rejected as invalid. Services exposing compressed-proof APIs can therefore suffer reliable denial of service, and integrations built with `panic=abort`, `no_std`, or weak panic isolation may lose the entire verification worker or process.

</details>

<details>
<summary><b>#64708 · Medium · Short Merkle leaves are not uniquely committed</b></summary>

**Targets**
- Hasher::hash_or_noop
- merkle_proofs::verify_batch_merkle_proof_to_cap
- HashOut::from_bytes
- MerkleTree::new
- merkle_tree::fill_subtree
- BatchMerkleTree::new

**Affected Locations**
- **Hasher.hash_or_noop**: Short inputs are copied into a fixed-width zero-initialized digest buffer instead of being length-tagged and hashed.
- **merkle_proofs.verify_batch_merkle_proof_to_cap**: Verification recomputes the same ambiguous short digests from supplied `leaf_data`, so substituted openings still pass.
- **HashOut.from_bytes**: The fixed-width buffer is decoded directly into `HashOut<F>`, which erases the original short-leaf length and preserves digest/leaf ambiguity.
- **MerkleTree.new**: The constructor accepts arbitrary `Vec<Vec<F>>` leaves without enforcing a fixed leaf width before compression.
- **merkle_tree.fill_subtree**: Leaf nodes are reduced with `H::hash_or_noop`, so ambiguous short encodings enter the tree unchanged.
- **BatchMerkleTree.new**: Batch-tree construction commits raw row vectors without encoding row length before hashing.
- **Poseidon2Hash.two_to_one**: Poseidon2 chooses a 32-byte `HashOut<F>` digest, activating the short-leaf `hash_or_noop` path for up to four field elements.
- **Poseidon2Hash.hash_or_noop**: Short leaves are encoded into a zero-initialized fixed-size 32-byte buffer instead of being hashed.
- **Poseidon2Hash.from_bytes**: The fixed-size buffer is decoded as four field elements, erasing the original leaf length.
- **Poseidon2Hash.fill_subtree**: Merkle tree construction uses `hash_or_noop` for leaves.
- **Poseidon2Hash.verify_batch_merkle_proof_to_cap**: Proof verification starts from `hash_or_noop(leaf_data)` and never checks or commits the original leaf length.
- **BatchMerkleTree.verify_batch_merkle_proof_to_cap**: Verification recomputes the same ambiguous digest from attacker-supplied `leaf_data`.
- **BatchMerkleTree.fill_digests_buf**: Leaf digests are computed with `H::hash_or_noop` when the subtree is at cap height.
- **MerkleTree.fill_subtree**: Base-case leaf hashing uses `H::hash_or_noop(&leaves[0])`.
- **MerkleTree.fill_digests_buf**: Cap-only trees hash each leaf directly with `H::hash_or_noop` as well.
- **MerkleTree.verify_batch_merkle_proof_to_cap**: Proof verification recomputes the leaf digest with the same `H::hash_or_noop` logic before comparing against the Merkle cap.
- **HashOut.hash_or_noop**: `HashOut<F>` accepts the fixed 32-byte buffer directly as four field elements, with no length/domain binding.
- **MerkleProof.verify_batch_merkle_proof_to_cap**: Verification recomputes the same ambiguous leaf digest from attacker-supplied `leaf_data`.

**Description**

`hash_or_noop` treats short inputs as if they were already hashed by copying their field encodings into a zero-initialized `HashOut<F>` buffer instead of running a real hash. Because neither a leaf-domain tag nor the original vector length is committed, distinct short vectors that differ only by trailing zero elements collapse to the same digest, and a 4-element input can also be chosen to equal a raw `HashOut<F>` value verbatim. `MerkleTree::new`, `fill_subtree`, and `BatchMerkleTree::new` all feed raw leaves or `cap_hash || row` concatenations through this helper, so both ordinary leaves and higher batch layers inherit the ambiguity. `verify_batch_merkle_proof_to_cap` recomputes the same digest from attacker-controlled `leaf_data`, so the same proof can authenticate substituted short vectors, including empty higher-layer rows when the concatenation remains short. In Poseidon2-backed trees this shortcut applies to up to four field elements, so variable-length leaves are not binding unless leaf data is length/domain separated or widths are fixed.

**Root cause**

`hash_or_noop` encodes short leaves as fixed-width `HashOut<F>` bytes without committing a leaf-specific domain tag or the original input length.

**Impact**

An attacker can reuse one Merkle proof or cap to authenticate alternate short leaf values that only differ by appended or omitted zero elements, and can sometimes repackage existing digests as synthetic leaves. Any downstream protocol that treats row width, trailing zeros, or higher-layer row presence as meaningful can therefore accept openings for data that was never uniquely committed under the published root.

**Remediation**

_Explanation_

- Replace the short-input `from_bytes` no-op in `Hasher::hash_or_noop` for Merkle-bound data with a real hash over a leaf-domain-separated encoding that includes the exact leaf length, and apply that same encoding in both tree construction and proof verification for raw leaves and `cap_hash || row` inputs. This removes the trailing-zero, empty-row, and raw-digest aliasing at the source without changing the Merkle tree structure or verifier flow.

---

</details>

<details>
<summary><b>#64709 · Medium · Poseidon2 recursive Merkle hashing ignores branch direction</b></summary>

**Targets**
- Poseidon2Hash::permute_swapped
- AlgebraicHasher::permute_swapped
- CircuitBuilder::permute_swapped
- CircuitBuilder::verify_merkle_proof_to_cap_with_cap_index
- CircuitBuilder::verify_merkle_proof
- CircuitBuilder::fri_verify_initial_proof

**Affected Locations**
- **Poseidon2Hash.permute_swapped**: The Poseidon2 in-circuit permutation ignores `swap` and always wires inputs in their original order.
- **AlgebraicHasher.permute_swapped**: The trait contract defines `permute_swapped` as a conditional swap used by Merkle-proof gadgets.
- **CircuitBuilder.permute_swapped**: The builder forwards the branch bit to the selected hasher and assumes the hasher implements the conditional-swap semantics.
- **CircuitBuilder.verify_merkle_proof_to_cap_with_cap_index**: This Merkle verification helper passes each path bit into `permute_swapped` when recomputing parent hashes.
- **CircuitBuilder.verify_merkle_proof**: The same branch-dependent hashing pattern is reused in the additional Merkle verification helper, broadening the affected call surface.
- **CircuitBuilder.fri_verify_initial_proof**: Recursive FRI verification invokes the Merkle gadget with Poseidon2, extending the bug to recursive proof validation.
- **Poseidon2Hash.verify_merkle_proof_to_cap_with_cap_index**: Recursive Merkle verification passes each path bit into `permute_swapped` to choose child ordering.
- **Poseidon2Hash.verify_batch_merkle_proof_to_cap**: Native verification uses the bit to choose between left/right digest orderings.
- **Poseidon2GoldilocksConfig.permute_swapped**: Poseidon2 is the active hasher and inner hasher for this configuration.
- **Poseidon2Hash.fri_verify_initial_proof**: Recursive FRI verification invokes in-circuit Merkle proof verification for proof authentication paths.
- **CircuitBuilder.verify_batch_merkle_proof_to_cap_with_cap_index**: The same branch-dependent hashing pattern is reused in batched Merkle verification.
- **Poseidon2GoldilocksConfig.verify_merkle_proof_to_cap**: `cap_index` is derived from the high bits above the sibling depth.
- **Poseidon2GoldilocksConfig.verify_merkle_proof_to_cap_with_cap_index**: Each lower Merkle path bit is supposed to drive `permute_swapped` when combining `state` and `sibling`.
- **Poseidon2GoldilocksConfig.fri_verify_query_round**: Recursive FRI verification derives query index bits and passes them into Merkle-proof verification.
- **Poseidon2GoldilocksConfig.fri_verify_initial_proof**: The recursive verifier uses the generic Merkle gadget with `H: AlgebraicHasher<F>` for each initial-tree opening.

**Description**

`Poseidon2Hash::permute_swapped` accepts a `swap` bit but never uses it, so the in-circuit permutation always hashes the first chunk before the second chunk. The Merkle gadgets in `plonky2/src/hash/merkle_proofs.rs` call `permute_swapped(..., bit)` at each tree level specifically to choose between `state || sibling` and `sibling || state` based on the path bit. That behavior matches the documented `AlgebraicHasher::permute_swapped` contract and the native Merkle verifier, but the Poseidon2 implementation violates the contract and drops the left/right ordering information. Under `Poseidon2GoldilocksConfig`, this affects recursive FRI/PLONK verification and other in-circuit Merkle checks that use Poseidon2 as both `Hasher` and `InnerHasher`. As a result, parent hashes are computed incorrectly whenever a Merkle path contains a `1` bit, so the recursive circuit no longer agrees with the native tree semantics.

**Root cause**

`Poseidon2Hash::permute_swapped` discards `swap` instead of conditionally swapping the Merkle input chunks before wiring them into the Poseidon2 permutation.

**Impact**

Honest Poseidon2-based Merkle proofs and recursive proofs with any right-branch step can be rejected even though they are valid under the native verifier. Systems that depend on `Poseidon2GoldilocksConfig` for recursive verification or in-circuit membership checks can therefore be driven into deterministic verification failure and lose availability for those proof flows.

</details>

<details>
<summary><b>#64710 · Medium · Generic circuit hashing does not implement Poseidon2 semantics</b></summary>

**Targets**
- CircuitBuilder::hash_n_to_hash_no_pad
- CircuitBuilder::verify_merkle_proof_to_cap_with_cap_index
- CircuitBuilder::build
- CircuitBuilder::hash_or_noop
- CircuitBuilder::hash_n_to_m_no_pad
- Poseidon2Hash::hash_no_pad

**Affected Locations**
- **CircuitBuilder.hash_n_to_hash_no_pad**: Hashes `InnerHasher` inputs in-circuit with the framework's generic sponge instead of Poseidon2's padded additive hash.
- **CircuitBuilder.verify_merkle_proof_to_cap_with_cap_index**: Seeds recursive Merkle verification from `hash_or_noop`, so long leaf payloads are hashed under the wrong semantics.
- **CircuitBuilder.build**: Computes `public_inputs_hash` with `hash_n_to_hash_no_pad::<C::InnerHasher>`, causing circuit public-input hashing to diverge from the native Poseidon2 prover.
- **CircuitBuilder.hash_or_noop**: Routes inputs longer than `NUM_HASH_OUT_ELTS` into the generic in-circuit hash path, triggering the mismatch for long Poseidon2 leaves.
- **CircuitBuilder.hash_n_to_m_no_pad**: Implements overwrite-mode absorption without Poseidon2 padding, which is the behavior inherited by the generic circuit hash helper.
- **Poseidon2Hash.hash_no_pad**: Defines the native Poseidon2 digest via `hash_n_to_hash_no_pad_p2`, so it disagrees with the generic circuit helper.
- **Poseidon2Hash.hash_or_noop**: Circuit `hash_or_noop` falls back to `hash_n_to_hash_no_pad` for inputs longer than four field elements.
- **Poseidon2Hash.hash_n_to_hash_no_pad**: The circuit fallback uses the generic no-pad sponge helper rather than Poseidon2-specific padding.
- **Poseidon2Hash.verify_merkle_proof_to_cap_with_cap_index**: Recursive Merkle verification seeds the path from circuit `hash_or_noop`.
- **Poseidon2Hash.fri_verify_initial_proof**: Recursive FRI verification feeds Merkle-opening leaf payloads into the recursive Merkle verifier under the active hasher.
- **Poseidon2GoldilocksConfig.build**: The config selects `Poseidon2Hash` as `InnerHasher`.
- **Poseidon2GoldilocksConfig.hash_n_to_hash_no_pad**: Generic in-circuit hashing delegates to overwrite-mode `hash_n_to_m_no_pad`.
- **Poseidon2GoldilocksConfig.hash_n_to_m_no_pad**: Absorption overwrites the state chunk and performs no Poseidon2 padding.
- **Poseidon2GoldilocksConfig.prove**: The prover transcript hashes public inputs natively with `C::InnerHasher::hash_no_pad`.
- **Poseidon2GoldilocksConfig.verify_proof**: Recursive verification repeats the same generic in-circuit hashing mismatch for `C::InnerHasher`.

**Description**

The generic in-circuit hashing helpers assume the framework's overwrite-mode sponge, but `Poseidon2Hash` native hashing uses the Poseidon2-specific padded additive sponge in `hash_n_to_hash_no_pad_p2`. When `CircuitBuilder::hash_or_noop` receives more than `NUM_HASH_OUT_ELTS` field elements, it routes to `hash_n_to_hash_no_pad`, so recursive Merkle verification hashes long leaves under different semantics than the native Merkle tree. The same generic helper is also used when `build` hashes public inputs for `C::InnerHasher`, while the prover computes `public_inputs_hash` with `C::InnerHasher::hash_no_pad`. Under `Poseidon2GoldilocksConfig`, both code paths therefore disagree with the advertised hasher and no longer derive the same digest as native proving and verification. The implementation only stays consistent when inputs are short enough to bypass hashing entirely.

**Root cause**

Generic circuit helpers such as `hash_n_to_hash_no_pad` and `hash_or_noop` hardcode overwrite-mode, no-padding absorption, but `Poseidon2Hash::hash_no_pad` uses the padded additive Poseidon2 sponge.

**Impact**

Any Poseidon2 configuration that hashes long leaf payloads or public inputs in-circuit can deterministically fail because the circuit and native prover derive different digests from the same data. An attacker can submit work under `Poseidon2GoldilocksConfig` that wastes proving resources or makes recursive FRI and proof verification unavailable whenever these mismatched paths are exercised.

</details>

<details>
<summary><b>#64711 · Medium · Unvalidated circuit metadata can panic or hang verification</b></summary>

**Targets**
- Buffer::read_common_circuit_data
- Buffer::read_circuit_config
- Buffer::read_selectors_info
- Buffer::read_lut
- CircuitBuilder::check_config
- verifier::verify_with_challenges
- vanishing_poly::eval_vanishing_poly
- vanishing_poly::check_lookup_constraints
- vanishing_poly::evaluate_gate_constraints
- Gate::eval_filtered
- Gate::compute_filter
- CommonCircuitData::get_fri_instance
- partial_products::check_partial_products
- Forest::wire_partition
- VerifierCircuitData::from_bytes
- CommonCircuitData::from_bytes
- verifier::verify
- CommonCircuitData::permutation_partial_product_degree
- CommonCircuitData::lookup_accumulator_degree

**Affected Locations**
- **Buffer.read_common_circuit_data**: Constructs `CommonCircuitData` from untrusted fields without validating cross-field invariants.
- **Buffer.read_circuit_config**: Reads wire counts, challenge counts, and FRI config directly from bytes.
- **Buffer.read_selectors_info**: Accepts arbitrary selector indices and group ranges without consistency checks.
- **Buffer.read_lut**: Allows zero-length LUTs and other malformed lookup-table contents.
- **CircuitBuilder.check_config**: Configuration validation omits routed-wire and other structural bounds needed later.
- **verifier.verify_with_challenges**: Uses unvalidated degree factors when reconstructing quotient chunks.
- **vanishing_poly.eval_vanishing_poly**: Fans malformed metadata into lookup, gate, and permutation checks.
- **vanishing_poly.check_lookup_constraints**: Assumes valid lookup polynomial counts, selector layout, and LUT mapping.
- **vanishing_poly.evaluate_gate_constraints**: Indexes selector metadata and gate-aligned arrays without bounds checks.
- **Gate.eval_filtered**: Reads selector constants directly from `vars.local_constants[selector_index]`.
- **Gate.compute_filter**: Iterates the full attacker-supplied selector range, enabling excessive work.
- **CommonCircuitData.get_fri_instance**: Derives subgroup generators from unchecked degree metadata.
- **partial_products.check_partial_products**: Assumes chunk counts and sizes are consistent and asserts otherwise.
- **Forest.wire_partition**: Indexes the witness-grid partition using unchecked routed-wire bounds.
- **VerifierCircuitData.from_bytes**: Deserializer entrypoint that accepts attacker-controlled verifier bytes.
- **CommonCircuitData.from_bytes**: Deserializer entrypoint that accepts attacker-controlled common circuit bytes.
- **verifier.verify**: Top-level verifier only validates proof shape before consuming metadata.
- **CommonCircuitData.permutation_partial_product_degree**: Derives chunk sizes from unchecked `quotient_degree_factor`.
- **CommonCircuitData.lookup_accumulator_degree**: Performs unchecked subtraction from `quotient_degree_factor` for lookup chunking.
- **CommonVerifierData.get_lut_poly**: Deserializer accepts arbitrary lookup-table count and pushes each parsed LUT without semantic validation.
- **CommonVerifierData.eval_vanishing_poly**: Deserializer reads `num_lookup_polys` and `num_lookup_selectors` without validating lookup invariants.
- **CommonVerifierData.evaluate_gate_constraints**: Selector indices and groups are deserialized from bytes without semantic validation.
- **CommonVerifierData.check_partial_products**: Circuit config fields controlling routed-wire count and quotient degree are attacker-controlled at deserialization time.
- **CommonVerifierData.permutation_partial_product_degree**: `quotient_degree_factor` is deserialized without lower-bound validation.
- **verifier.eval_vanishing_poly**: Unchecked lookup metadata is forwarded into `check_lookup_constraints`.
- **verifier.check_lookup_constraints**: `num_sldc_polys` can become zero, making `div_ceil(num_sldc_polys)` invalid.
- **verifier.validate_proof_shape**: Shape validation only enforces the quotient-opening count derived from `num_quotient_polys()`.
- **CommonCircuitData.num_quotient_polys**: A zero `quotient_degree_factor` makes the expected quotient-opening count zero, allowing malformed metadata through shape checks.
- **CommonVerifierData.from_bytes**: Deserializes common verifier data directly from attacker-controlled bytes.
- **VerifierCircuitData, CommonVerifierData.from_bytes**: Reads critical metadata fields and constructs `CommonCircuitData` without validating cross-field invariants beyond `fri_oracle_layouts_len >= 4`.
- **CommonVerifierData.degree**: Unchecked shifts and root-of-unity derivation rely on deserialized degree-bit fields being valid.
- **Read.read_selectors_info**: Selector indices and groups are accepted without bounds or consistency validation.
- **Read.read_common_circuit_data**: Arbitrary gate count is deserialized independently from selector metadata.
- **CommonCircuitData.evaluate_gate_constraints**: Verification blindly indexes `selector_indices[i]` and `groups[selector_index]`.
- **Read.read_fri_params**: FRI degree parameters are deserialized without any bound checks.
- **CommonVerifierData.get_fri_instance**: Verification derives a root of unity from attacker-controlled `degree_bits`.
- **Field.primitive_root_of_unity**: The field code asserts that the requested degree fits the field's two-adicity.
- **FriChallenger.fri_challenges**: FRI challenge derivation shifts by attacker-controlled `degree_bits + rate_bits` to size the LDE domain.
- **VerificationGate.read_selectors_info**: Selector indices and group ranges are read with no consistency or bounds validation.
- **VerificationGate.read_common_circuit_data**: Deserialized selector metadata is embedded into `CommonCircuitData` and returned without validation.
- **VerificationGate.evaluate_gate_constraints**: Verification indexes `selector_indices[i]` and `groups[selector_index]` for every gate.
- **VerificationGate.eval_filtered**: Gate filtering indexes `vars.local_constants[selector_index]` directly.
- **VerificationGate.compute_filter**: Filter computation iterates the entire supplied selector range with no bound on work.
- **N/A.get_lut_poly**: `get_lut_poly` unconditionally reads `common_data.luts[lut_index][0]` when building padded LUT coefficients.
- **N/A.eval_vanishing_poly**: Any nonzero `num_lookup_polys` enables lookup processing and calls `check_lookup_constraints` with slices derived from metadata.
- **N/A.check_lookup_constraints**: Derives `num_sldc_polys = local_lookup_zs.len() - 1`, divides by it, indexes `num_sldc_polys - 1`, and evaluates LUT polynomials for final RE checks.
- **N/A.verify**: Verifier proceeds from shape validation to challenge generation using the supplied `common_data`.
- **N/A.verify_with_challenges**: Verification always evaluates the vanishing polynomial against the provided `common_data`.
- **N/A.evaluate_gate_constraints**: Gate evaluation indexes `selector_indices[i]`, `groups[selector_index]`, and passes the selector-derived layout into gate filtering.
- **partial_products.num_partial_products**: Underflows on `n == 0` and assumes a positive chunk size.
- **partial_products.permutation_partial_product_degree**: Derived chunk size can become zero for malformed deserialized degree factors.
- **partial_products.verify**: Verification accepts the deserialized common data and derives challenges.
- **partial_products.verify_with_challenges**: Verification calls `eval_vanishing_poly`, which reaches `check_partial_products`.
- **CircuitConfig.num_advice_wires**: `CircuitConfig` exposes unconstrained wire-count fields and helper logic assumes subtraction is valid.
- **CircuitConfig.read_circuit_config**: Untrusted bytes are converted directly into `CircuitConfig` with no invariant checks.
- **CircuitConfig.validate_proof_shape**: Shape validation checks `wires` and `plonk_sigmas` lengths independently, so inconsistent counts still pass.
- **CircuitConfig.eval_vanishing_poly**: Verification indexes `vars.local_wires[j]` for every routed wire, which panics when routed wires exceed total wires.
- **CircuitConfig.verify**: Top-level verifier entrypoint reaches the panicking path after only shape validation.
- **Target.index**: Wire indices are derived from `num_wires`, not `num_routed_wires`.
- **CircuitBuilder.sigma_vecs**: Build path passes config values into `Forest` and calls `wire_partition`.

**Description**

The verifier and related builder code deserialize `CommonCircuitData`, `VerifierCircuitData`, `SelectorsInfo`, LUTs, and `CircuitConfig` directly from bytes or caller-supplied metadata, but they only perform shallow shape checks before using those values in arithmetic, slicing, indexing, and iteration. As a result, malformed inputs such as empty LUTs, `num_lookup_polys == 1`, mismatched lookup-selector counts, inconsistent selector tables, short `k_is` vectors, bad `num_partial_products`, zero or undersized `quotient_degree_factor`, oversized degree bits, `num_routed_wires > num_wires`, or attacker-chosen selector ranges can reach panic-prone code paths. Those paths include direct indexing in `get_lut_poly`, `check_lookup_constraints`, `evaluate_gate_constraints`, and permutation checks, zero-sized chunking in quotient and partial-product reconstruction, root-of-unity assertions in FRI setup, and unbounded iteration in `compute_filter`. Because the existing validators mostly compare proof vector lengths against the same attacker-controlled metadata, malformed artifacts can satisfy shape checks and still crash or stall the process later in verification. The implementation work needed here is the same across these reports: add a single semantic validation pass for deserialized circuit/config metadata and reject inconsistent values before any verifier or builder helper consumes them.

**Root cause**

The code trusts deserialized `CommonCircuitData` and `CircuitConfig` fields without enforcing cross-field invariants up front, so later helpers execute unchecked indexing, division, chunking, shifts, assertions, and range iteration on attacker-controlled values.

**Impact**

An attacker who can supply serialized circuit or verifier artifacts can make verification abort or hang on demand, taking verifier workers or proof-checking endpoints offline instead of returning a clean `Err`. The same missing validation also lets malformed configs crash circuit-building or sigma-generation paths, so services that build or cache circuits from untrusted inputs can be denied service before proof handling completes.

**Remediation**

_Explanation_

- Add a single semantic validation pass for `CircuitConfig` and `CommonCircuitData` immediately after deserialization and before any gate, lookup, permutation, quotient, or FRI helper can read those fields. Reject metadata unless all cross-field invariants hold, including routed-wire bounds, `k_is` length, nonzero and sufficiently large `quotient_degree_factor`, consistent `num_partial_products`, selector index/group consistency, lookup-mode consistency (`num_lookup_polys`, `num_lookup_selectors`, LUT count, non-empty LUTs), and degree/rate parameters that stay within field two-adicity and shift limits.

- Call that validator from every metadata entrypoint that constructs or accepts these objects (`read_*`, `from_bytes`, and builder/verify paths that consume caller-supplied config/common data) and fail with `Err` on invalid metadata. Keep downstream shape checks unchanged, but make them operate only on already-validated metadata so attacker-controlled values never reach panic-prone indexing, chunking, subtraction, assertions, or unbounded iteration.

---

</details>

<details>
<summary><b>#64712 · Medium · Malformed gate metadata can panic circuit loading and verification</b></summary>

**Targets**
- Buffer::read_common_circuit_data
- DefaultGateSerializer::read_gate
- LookupGate::deserialize
- LookupTableGate::deserialize
- ArithmeticGate::deserialize
- ArithmeticExtensionGate::deserialize
- MulExtensionGate::deserialize
- ConstantGate::deserialize
- BaseSumGate::deserialize
- ExponentiationGate::deserialize
- CosetInterpolationGate::deserialize
- RandomAccessGate::deserialize
- ReducingGate::deserialize
- ReducingExtensionGate::deserialize
- PublicInputGate::deserialize
- PoseidonGate::eval_unfiltered
- PoseidonMdsGate::eval_unfiltered
- VerifierCircuitData::from_bytes
- CommonCircuitData::from_bytes
- CircuitData::from_bytes
- validate_shape::validate_proof_with_pis_shape

**Affected Locations**
- **Buffer.read_common_circuit_data**: Builds `CommonCircuitData` from attacker-controlled bytes and stores deserialized gates without a gate-vs-config validation pass.
- **DefaultGateSerializer.read_gate**: Dispatches serialized gate tags directly into gate-specific `deserialize` implementations.
- **LookupGate.deserialize**: Uses a serialized LUT index to access `common_data.luts` without bounds checking.
- **LookupTableGate.deserialize**: Uses a serialized LUT index to access `common_data.luts` without bounds checking.
- **ArithmeticGate.deserialize**: Accepts serialized `num_ops` without checking whether the gate fits the configured wire budget.
- **ArithmeticExtensionGate.deserialize**: Accepts serialized `num_ops` without checking whether the derived extension-wire ranges fit the circuit.
- **MulExtensionGate.deserialize**: Accepts serialized `num_ops` without validating the resulting wire ranges against `config.num_wires`.
- **ConstantGate.deserialize**: Accepts serialized `num_consts` without validating compatibility with circuit constants and wires.
- **BaseSumGate.deserialize**: Accepts serialized `num_limbs` without checking that the limb slice fits inside local wires.
- **ExponentiationGate.deserialize**: Accepts serialized `num_power_bits` without checking nonzero and wire-budget invariants.
- **CosetInterpolationGate.deserialize**: Accepts serialized `subgroup_bits`, `degree`, and `barycentric_weights` without re-establishing constructor invariants.
- **RandomAccessGate.deserialize**: Accepts serialized `bits`, `num_copies`, and `num_extra_constants` without validating implied wire and constant ranges.
- **ReducingGate.deserialize**: Accepts serialized `num_coeffs` without validating the resulting wire footprint or zero-coefficient edge cases.
- **ReducingExtensionGate.deserialize**: Accepts serialized `num_coeffs` without validating derived extension-wire ranges or constraint counts.
- **PublicInputGate.deserialize**: Does not verify that the surrounding circuit provides the fixed four-wire layout the gate later reads.
- **PoseidonGate.eval_unfiltered**: Performs fixed-position reads from `local_wires`, panicking when the serialized circuit width is too small for the gate layout.
- **PoseidonMdsGate.eval_unfiltered**: Reads fixed extension-wire ranges and uses `unwrap()`, panicking when malformed metadata makes those ranges invalid.
- **VerifierCircuitData.from_bytes**: Public verifier-data entrypoint that accepts serialized circuit bytes.
- **CommonCircuitData.from_bytes**: Public common-data entrypoint that accepts serialized circuit bytes.
- **CircuitData.from_bytes**: Full circuit-data entrypoint that accepts serialized circuit and generator bytes.
- **validate_shape.validate_proof_with_pis_shape**: Checks only aggregate proof-opening lengths from `config` and does not reconcile them with each deserialized gate's local footprint.
- **CommonVerifierData.from_bytes**: Common verifier data also exposes direct deserialization from bytes.
- **DefaultGateSerializer.read_common_circuit_data**: After reading LUTs, gate bytes are parsed with `self.read_gate(gate_serializer, &common_data)`.
- **DefaultGateSerializer.validate_proof_shape**: Proof validation checks only global array lengths, not whether each gate's internal shape fits those bounds.
- **DefaultGateSerializer.verify**: Verification proceeds from shape validation into gate evaluation.
- **DefaultGateSerializer.evaluate_gate_constraints**: Every deserialized gate is evaluated during verification.
- **ExponentiationGate.eval_unfiltered**: Gate evaluation indexes wires based on `num_power_bits` and dereferences `intermediate_values[self.num_power_bits - 1]`.
- **MulExtensionGate.eval_unfiltered**: Wire ranges are derived from `self.num_ops` and used for reads on every iteration.
- **ExponentiationGate.num_wires**: Any call to num_wires also underflows when num_power_bits is zero.
- **ExponentiationGate.read_common_circuit_data**: Serialized gates are instantiated directly from untrusted bytes.
- **ExponentiationGate.from_bytes**: Public API for loading verifier circuit data from bytes.
- **ExponentiationGate.verify_with_challenges**: Verification evaluates the vanishing polynomial on loaded gate definitions.
- **ExponentiationGate.evaluate_gate_constraints**: Gate evaluation is invoked for every loaded gate during verification.
- **ExponentiationGenerator.run_once**: Witness generation repeats the unchecked final-index access.
- **ExponentiationGate.validate_proof_shape**: Only aggregate opening lengths are checked; gate-local width is not validated.
- **ExponentiationGate.verify**: Verification reaches gate evaluation after only shape checks.
- **CosetInterpolationGate.eval_unfiltered**: Uses deserialized fields in subgroup generation and unchecked slicing.
- **CosetInterpolationGate.num_constraints**: `num_intermediates` divides by `self.degree - 1`, so degree=1 is fatal.
- **CosetInterpolationGate.from_bytes**: Public entrypoint for attacker-controlled verifier circuit bytes.
- **CosetInterpolationGate.verify**: Verification evaluates vanishing polynomial, which reaches gate evaluation.
- **CosetInterpolationGate.evaluate_gate_constraints**: Calls each gate's evaluation function during verification.
- **ConstantGate.eval_unfiltered_base_packed**: Packed evaluation also iterates over untrusted `num_consts` and indexes constants/wires slices.
- **ConstantGate.eval_unfiltered**: Indexes `local_constants` and `local_wires` up to `self.num_consts`.
- **ConstantGate.eval_unfiltered_circuit**: Recursive evaluator uses the same unchecked indexing pattern.
- **ConstantGate.from_bytes**: Verifier-side API accepts serialized circuit data and dispatches into deserialization.
- **ArithmeticGate.eval_unfiltered**: Verification iterates `0..self.num_ops` and indexes four wire slots per operation.
- **BaseSumGate.eval_unfiltered**: `self.limbs()` is used directly to slice `local_wires`.
- **BaseSumGate.read_common_circuit_data**: Circuit config and gates are deserialized from bytes with no gate-vs-config consistency check.
- **BaseSumGate.verify**: Verification proceeds from deserialized common data into constraint evaluation.
- **BaseSumGate.evaluate_gate_constraints**: Verifier evaluates every gate, reaching the unchecked `BaseSumGate` slice.
- **ArithmeticExtensionGate.eval_unfiltered**: Verifier iterates over `num_ops` and slices extension-wire ranges derived from it.
- **ArithmeticExtensionGate.eval_unfiltered_base_one**: Base-field evaluation path has the same unchecked range derivation.
- **PoseidonGate.num_wires**: The gate declares its required wire footprint via `Self::end()`, but this is not enforced during verifier-side loading.
- **PoseidonGate.read_common_circuit_data**: Verifier-side circuit deserialization loads gates using the partially built `CommonCircuitData` and performs no compatibility check against `config.num_wires`.
- **PoseidonGate.validate_proof_shape**: Proof-shape validation only enforces `wires.len() == config.num_wires`, not that every configured gate fits in that width.
- **PoseidonGate.evaluate_gate_constraints**: Verification evaluates each configured gate against the proof's wire openings, which reaches the unchecked indexing in `PoseidonGate`.
- **ReducingGate.eval_unfiltered**: Evaluation reads wire ranges derived from `num_coeffs`.
- **ReducingGate.num_wires**: `num_wires` undercounts when `num_coeffs == 0`, while `num_constraints` also becomes zero.
- **ReducingGate.eval_unfiltered_base_one**: Base-field evaluation uses the same unvalidated ranges.
- **ReducingGate.eval_unfiltered_circuit**: Recursive-circuit evaluation also derives wire ranges directly from num_coeffs.
- **CommonCircuitData.read_common_circuit_data**: Serialized gates are accepted into common_data without per-gate size validation.
- **PublicInputGate.wires_public_inputs_hash**: The gate hard-codes four required wire positions.
- **RandomAccessGate.eval_unfiltered**: Verification indexes `local_wires` and `local_constants` using offsets derived from unvalidated fields.
- **ReducingExtensionGate.eval_unfiltered_base_one**: Evaluation iterates over `0..self.num_coeffs` and reads computed wire ranges from `vars` without bounds checks.
- **ReducingExtensionGate.eval_unfiltered**: `num_coeffs` drives wire-range reads and constraint generation.
- **ReducingExtensionGate.num_constraints**: Constraint count is derived directly from attacker-controlled `num_coeffs`.
- **PoseidonMdsGate.wires_input**: Gate defines fixed input/output wire ranges up to `2 * D * SPONGE_WIDTH`.

**Description**

`from_bytes` paths for `VerifierCircuitData`, `CommonCircuitData`, and `CircuitData` reconstruct gates from attacker-controlled bytes via `read_common_circuit_data` and `read_gate`, then trust the resulting gate objects. Some deserializers panic immediately on malformed fields, such as `LookupGate` and `LookupTableGate` indexing `common_data.luts[lut_index]` without verifying that the serialized LUT index exists. Many other gates accept unsafe structural parameters like `num_ops`, `num_power_bits`, `num_limbs`, `num_coeffs`, `degree`, `bits`, or fixed wire layouts without checking them against `common_data.config`, `common_data.num_constants`, or `common_data.num_gate_constraints`. Later proving and verification paths only validate aggregate opening lengths from `config`, then use those gate-local fields inside `eval_unfiltered` and related helpers to derive wire, constant, and constraint ranges, where unchecked indexing, slicing, arithmetic like `self.degree - 1`, and `unwrap()` can panic. As a result, malformed serialized artifacts can crash during deserialization itself or after loading when gate evaluation runs, instead of returning `IoError` or an ordinary verification failure.

**Root cause**

`read_gate` and the various gate `deserialize` implementations trust serialized gate selection and parameters without revalidating them against `CommonCircuitData`, so malformed metadata reaches unchecked LUT, wire, constant, and constraint accesses.

**Impact**

An attacker who can supply serialized circuit, verifier, or prover artifacts can crash `from_bytes`, `verify`, or witness/proving execution with a single malformed payload. Services that ingest third-party artifacts can therefore be repeatedly forced into panic-driven denial of service unless they isolate these code paths externally.

</details>

<details>
<summary><b>#64713 · Medium · Lookup deserializers panic on unvalidated serialized indices</b></summary>

**Targets**
- LookupGate::deserialize
- LookupTableGate::deserialize
- LookupGenerator::deserialize
- LookupGenerator::run_once
- LookupTableGenerator::deserialize
- PartitionWitness::set_target_returning_rep
- PartitionWitness::try_get_target
- VerifierCircuitData::from_bytes
- CommonVerifierData::from_bytes
- Buffer::read_common_circuit_data
- CommonCircuitData::from_bytes
- ProverOnlyCircuitData::from_bytes
- Buffer::read_prover_only_circuit_data
- Target::index

**Affected Locations**
- **LookupGate.deserialize**: Uses serialized `lut_index` to access `common_data.luts` without bounds checks.
- **LookupTableGate.deserialize**: Uses serialized `lut_index` to access `common_data.luts` without bounds checks.
- **LookupGenerator.deserialize**: Accepts serialized `row`, `slot_nb`, and `lut_index` without validating LUT existence or derived wire coordinates.
- **LookupGenerator.run_once**: Converts unchecked `row` and `slot_nb` into `Target::wire(...)` accesses during witness generation.
- **LookupTableGenerator.deserialize**: Repeats the unchecked `lut_index` lookup in generator deserialization.
- **PartitionWitness.set_target_returning_rep**: Witness writes index `representative_map` using the unchecked target-derived index.
- **PartitionWitness.try_get_target**: Witness reads index `representative_map` using the unchecked target-derived index.
- **VerifierCircuitData.from_bytes**: Public verifier-data deserialization entrypoint for attacker-controlled bytes.
- **CommonVerifierData.from_bytes**: Public common-data deserialization entrypoint that feeds untrusted bytes into lookup gate deserializers.
- **Buffer.read_common_circuit_data**: Builds `common_data.luts` from serialized input and then dispatches into gate deserializers.
- **CommonCircuitData.from_bytes**: Public common-data deserialization entrypoint for serialized circuit artifacts.
- **ProverOnlyCircuitData.from_bytes**: Public prover-data deserialization entrypoint that exposes generator deserialization to untrusted bytes.
- **Buffer.read_prover_only_circuit_data**: Reads serialized generators and passes them into generator deserializers using attacker-influenced metadata.
- **Target.index**: Turns unchecked wire coordinates into raw indices without bounds checks.
- **LookupGate.read_common_circuit_data**: Deserializes LUTs and then invokes gate deserializers on untrusted bytes.
- **LookupGate.read_prover_only_circuit_data**: Serialized generators are read from the byte stream and passed into generator deserializers.
- **LookupGate.set_target_returning_rep**: Witness writes use the unchecked target-derived index to access `representative_map`.
- **LookupGate.try_get_target**: Witness reads also index `representative_map` directly using the unchecked target-derived index.

**Description**

Multiple lookup-related deserializers accept serialized lookup metadata as trusted and use it without bounds checks. In both the `verifier` and `plonky2` codepaths, `LookupGate::deserialize`, `LookupTableGate::deserialize`, `LookupGenerator::deserialize`, and `LookupTableGenerator::deserialize` read `lut_index` from attacker-controlled bytes and immediately access `common_data.luts[lut_index]`. The public `from_bytes` entrypoints first populate `common_data.luts` from the same untrusted byte stream and then dispatch into these deserializers, so malformed artifacts reach the unchecked access during normal API use. In `plonky2`, the generator path also accepts serialized `row` and `slot_nb` values and later converts them into `Target::wire(...)` coordinates that flow into unchecked witness indexing. The fix is to validate every serialized lookup reference and coordinate against `common_data.luts`, valid slot ranges, and witness dimensions before constructing the gate or generator, and to return `IoResult::Err` for malformed input instead of panicking.

**Root cause**

The lookup `deserialize` implementations trust attacker-controlled `lut_index` and, in one generator path, `row` and `slot_nb`, then use those values in direct indexing or derived wire accesses without validating bounds and converting failures into `IoResult` errors.

**Impact**

An attacker who can supply serialized circuit or prover artifacts can trigger a panic with a single malformed payload, either while the artifact is being deserialized or later when lookup witness generation runs. Applications that accept uploaded or network-supplied circuit data may abort requests or terminate the process instead of rejecting invalid input cleanly, enabling repeatable denial of service.

</details>

<details>
<summary><b>#64714 · Medium · Empty lookup tables panic during build and witness generation</b></summary>

**Targets**
- CircuitBuilder::update_luts_from_pairs
- CircuitBuilder::update_luts_from_table
- CircuitBuilder::update_luts_from_fn
- CircuitBuilder::add_all_lookups
- LookupTableGenerator::run_once
- CircuitBuilder::add_lookup_table_from_pairs
- CircuitBuilder::add_lookup_table_from_table
- CircuitBuilder::add_lookup_table_from_fn

**Affected Locations**
- **CircuitBuilder.update_luts_from_pairs**: Stores caller-supplied LUTs as-is and does not reject an empty table before appending it to `self.luts`.
- **CircuitBuilder.update_luts_from_table**: Builds a LUT from zipped slices and stores it without validating that the resulting table is non-empty.
- **CircuitBuilder.update_luts_from_fn**: Constructs a LUT from `inputs` and stores it even when the generated table is empty.
- **CircuitBuilder.add_all_lookups**: Materialization computes `(self.get_luts_idx_length(lut_index) - 1) / num_lut_entries + 1`, which is invalid for an empty LUT.
- **LookupTableGenerator.run_once**: Padding logic falls back to `self.lut[0]` and asserts non-emptiness, so an empty LUT panics during witness generation.
- **CircuitBuilder.add_lookup_table_from_pairs**: Public helper accepts an arbitrary `LookupTable` and forwards it without checking that it contains at least one entry.
- **CircuitBuilder.add_lookup_table_from_table**: Public helper allows empty `inps` and `outs` slices, producing an empty stored LUT.
- **CircuitBuilder.add_lookup_table_from_fn**: Public helper can create an empty LUT when called with an empty `inputs` slice.
- **CircuitBuilder.build**: Circuit finalization always materializes lookup tables through `add_all_lookups`.

**Description**

The lookup-table pipeline assumes every stored table has at least one entry, but the public registration helpers and backing `update_luts_*` routines accept and store empty tables unchanged. Once such a table is referenced, `add_all_lookups` computes `num_lut_rows` as `(len - 1) / num_lut_entries + 1`, which underflows or panics when `len == 0` and can also drive excessive row allocation in unchecked builds. A second failure point exists in `LookupTableGenerator::run_once`, which pads incomplete slots from `self.lut[0]` and only guards that access with `assert!(!self.lut.is_empty())`. Because callers can supply an empty `LookupTable`, empty input/output slices, or an empty `inputs` list for `add_lookup_table_from_fn`, malformed data reaches both paths without validation. The same fix addresses all of these cases: enforce a non-empty LUT invariant before storing or materializing lookup tables and reject invalid inputs with a normal error.

**Root cause**

The code relies on an unstated non-empty LUT invariant, but `add_lookup_table_from_pairs`, `add_lookup_table_from_table`, `add_lookup_table_from_fn`, and the `update_luts_*` storage paths never enforce it before `add_all_lookups` and `LookupTableGenerator::run_once` perform `len - 1` arithmetic and `self.lut[0]` indexing.

**Impact**

Any service that builds circuits or generates witnesses from user-influenced lookup tables can be crashed with a single empty LUT submission. The process aborts during circuit finalization or witness generation, allowing repeated requests to keep proving or compilation workers unavailable.

</details>
