### PR TITLE
V12 audit (10/10): medium deserialization, lookup-slot & polynomial validation

### DIFF
--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -45,3 +45,4 @@ finding	severity	class	commit	status	notes
 64721	Medium	gadget-constraint-soundness	1a64dad7b	fixed	Power-table length mismatches silently truncate polynomial evaluation
 64722	Medium	runtime-dos-preconditions	3dbfa152f	fixed	secp256k1 field bigint constructors panic on oversized inputs
 64725	Medium	merkle-hash-binding	783cb705a	test-only-covered	Merkle leaf commitments already length-bound by c5f8b727a
+64726	Medium	untrusted-artifact-validation	0d3afd726	fixed	Unvalidated prover-data deserialization causes witness-generation panics

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -43,3 +43,4 @@ finding	severity	class	commit	status	notes
 64719	Medium	runtime-dos-preconditions	13227feb2	fixed	Unvalidated witness targets can panic the prover
 64720	Medium	runtime-dos-preconditions	0f0a12880	fixed	Empty polynomial coefficients cause release-mode panics
 64721	Medium	gadget-constraint-soundness	1a64dad7b	fixed	Power-table length mismatches silently truncate polynomial evaluation
+64722	Medium	runtime-dos-preconditions	3dbfa152f	fixed	secp256k1 field bigint constructors panic on oversized inputs

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -40,3 +40,4 @@ finding	severity	class	commit	status	notes
 64715	Medium	runtime-dos-preconditions	864969dbd	fixed	Zero lookup slot counts cause deterministic build panics
 64717	Medium	untrusted-artifact-validation	3e425ad83	test-only-covered	Missing commit-phase cap count check causes verifier panic; root fixed by a185fb932
 64718	Medium	untrusted-artifact-validation	caf9dc2db	fixed	Generator deserialization lacks bounds checks for witness coordinates
+64719	Medium	runtime-dos-preconditions	13227feb2	fixed	Unvalidated witness targets can panic the prover

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -37,3 +37,4 @@ finding	severity	class	commit	status	notes
 64712	Medium	untrusted-artifact-validation	f30021de9	fixed	Malformed gate metadata can panic circuit loading and verification
 64713	Medium	untrusted-artifact-validation	7b990e4c4	fixed	Lookup deserializers panic on unvalidated serialized indices
 64714	Medium	untrusted-artifact-validation	c2c88e97f	fixed	Empty lookup tables panic during build and witness generation
+64715	Medium	runtime-dos-preconditions	864969dbd	fixed	Zero lookup slot counts cause deterministic build panics

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -41,3 +41,4 @@ finding	severity	class	commit	status	notes
 64717	Medium	untrusted-artifact-validation	3e425ad83	test-only-covered	Missing commit-phase cap count check causes verifier panic; root fixed by a185fb932
 64718	Medium	untrusted-artifact-validation	caf9dc2db	fixed	Generator deserialization lacks bounds checks for witness coordinates
 64719	Medium	runtime-dos-preconditions	13227feb2	fixed	Unvalidated witness targets can panic the prover
+64720	Medium	runtime-dos-preconditions	0f0a12880	fixed	Empty polynomial coefficients cause release-mode panics

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -44,3 +44,4 @@ finding	severity	class	commit	status	notes
 64720	Medium	runtime-dos-preconditions	0f0a12880	fixed	Empty polynomial coefficients cause release-mode panics
 64721	Medium	gadget-constraint-soundness	1a64dad7b	fixed	Power-table length mismatches silently truncate polynomial evaluation
 64722	Medium	runtime-dos-preconditions	3dbfa152f	fixed	secp256k1 field bigint constructors panic on oversized inputs
+64725	Medium	merkle-hash-binding	783cb705a	test-only-covered	Merkle leaf commitments already length-bound by c5f8b727a

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -42,3 +42,4 @@ finding	severity	class	commit	status	notes
 64718	Medium	untrusted-artifact-validation	caf9dc2db	fixed	Generator deserialization lacks bounds checks for witness coordinates
 64719	Medium	runtime-dos-preconditions	13227feb2	fixed	Unvalidated witness targets can panic the prover
 64720	Medium	runtime-dos-preconditions	0f0a12880	fixed	Empty polynomial coefficients cause release-mode panics
+64721	Medium	gadget-constraint-soundness	1a64dad7b	fixed	Power-table length mismatches silently truncate polynomial evaluation

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -39,3 +39,4 @@ finding	severity	class	commit	status	notes
 64714	Medium	untrusted-artifact-validation	c2c88e97f	fixed	Empty lookup tables panic during build and witness generation
 64715	Medium	runtime-dos-preconditions	864969dbd	fixed	Zero lookup slot counts cause deterministic build panics
 64717	Medium	untrusted-artifact-validation	3e425ad83	test-only-covered	Missing commit-phase cap count check causes verifier panic; root fixed by a185fb932
+64718	Medium	untrusted-artifact-validation	caf9dc2db	fixed	Generator deserialization lacks bounds checks for witness coordinates

--- a/.v12-low-medium-findings-map.tsv
+++ b/.v12-low-medium-findings-map.tsv
@@ -38,3 +38,4 @@ finding	severity	class	commit	status	notes
 64713	Medium	untrusted-artifact-validation	7b990e4c4	fixed	Lookup deserializers panic on unvalidated serialized indices
 64714	Medium	untrusted-artifact-validation	c2c88e97f	fixed	Empty lookup tables panic during build and witness generation
 64715	Medium	runtime-dos-preconditions	864969dbd	fixed	Zero lookup slot counts cause deterministic build panics
+64717	Medium	untrusted-artifact-validation	3e425ad83	test-only-covered	Missing commit-phase cap count check causes verifier panic; root fixed by a185fb932

--- a/field/src/extension/algebra.rs
+++ b/field/src/extension/algebra.rs
@@ -175,12 +175,18 @@ impl<F: OEF<D>, const D: usize> PolynomialCoeffsAlgebra<F, D> {
             );
             return Ok(ExtensionAlgebra::ZERO);
         }
-        debug_assert_eq!(self.coeffs.len(), powers.len() + 1);
+        let expected_powers = self.coeffs.len() - 1;
+        ensure!(
+            powers.len() == expected_powers,
+            "polynomial power table length mismatch: expected {}, got {}",
+            expected_powers,
+            powers.len()
+        );
         let acc = self.coeffs[0];
         Ok(self.coeffs[1..]
             .iter()
-            .zip(powers)
-            .fold(acc, |acc, (&x, &c)| acc + c * x))
+            .enumerate()
+            .fold(acc, |acc, (i, &c)| acc + c * powers[i]))
     }
 
     /// Evaluate the polynomial at a point given its powers. The first power is the point itself, not 1.
@@ -208,12 +214,18 @@ impl<F: OEF<D>, const D: usize> PolynomialCoeffsAlgebra<F, D> {
             );
             return Ok(ExtensionAlgebra::ZERO);
         }
-        debug_assert_eq!(self.coeffs.len(), powers.len() + 1);
+        let expected_powers = self.coeffs.len() - 1;
+        ensure!(
+            powers.len() == expected_powers,
+            "polynomial power table length mismatch: expected {}, got {}",
+            expected_powers,
+            powers.len()
+        );
         let acc = self.coeffs[0];
         Ok(self.coeffs[1..]
             .iter()
-            .zip(powers)
-            .fold(acc, |acc, (&x, &c)| acc + x.scalar_mul(c)))
+            .enumerate()
+            .fold(acc, |acc, (i, &c)| acc + c.scalar_mul(powers[i])))
     }
 
     /// Evaluate the polynomial at a point given its powers. The first power is the point itself, not 1.

--- a/field/src/extension/algebra.rs
+++ b/field/src/extension/algebra.rs
@@ -3,6 +3,8 @@ use core::fmt::{self, Debug, Display, Formatter};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
+use anyhow::{ensure, Result};
+
 use crate::extension::OEF;
 
 /// Let `F_D` be the optimal extension field `F[X]/(X^D-W)`. Then `ExtensionAlgebra<F_D>` is the quotient `F_D[X]/(X^D-W)`.
@@ -162,13 +164,32 @@ impl<F: OEF<D>, const D: usize> PolynomialCoeffsAlgebra<F, D> {
     }
 
     /// Evaluate the polynomial at a point given its powers. The first power is the point itself, not 1.
-    pub fn eval_with_powers(&self, powers: &[ExtensionAlgebra<F, D>]) -> ExtensionAlgebra<F, D> {
+    pub fn try_eval_with_powers(
+        &self,
+        powers: &[ExtensionAlgebra<F, D>],
+    ) -> Result<ExtensionAlgebra<F, D>> {
+        if self.coeffs.is_empty() {
+            ensure!(
+                powers.is_empty(),
+                "empty polynomial must be evaluated with an empty power table"
+            );
+            return Ok(ExtensionAlgebra::ZERO);
+        }
         debug_assert_eq!(self.coeffs.len(), powers.len() + 1);
         let acc = self.coeffs[0];
-        self.coeffs[1..]
+        Ok(self.coeffs[1..]
             .iter()
             .zip(powers)
-            .fold(acc, |acc, (&x, &c)| acc + c * x)
+            .fold(acc, |acc, (&x, &c)| acc + c * x))
+    }
+
+    /// Evaluate the polynomial at a point given its powers. The first power is the point itself, not 1.
+    ///
+    /// This panics if the supplied power table is invalid. Use `try_eval_with_powers` for
+    /// untrusted inputs.
+    pub fn eval_with_powers(&self, powers: &[ExtensionAlgebra<F, D>]) -> ExtensionAlgebra<F, D> {
+        self.try_eval_with_powers(powers)
+            .expect("invalid polynomial power table")
     }
 
     pub fn eval_base(&self, x: F) -> ExtensionAlgebra<F, D> {
@@ -179,13 +200,29 @@ impl<F: OEF<D>, const D: usize> PolynomialCoeffsAlgebra<F, D> {
     }
 
     /// Evaluate the polynomial at a point given its powers. The first power is the point itself, not 1.
-    pub fn eval_base_with_powers(&self, powers: &[F]) -> ExtensionAlgebra<F, D> {
+    pub fn try_eval_base_with_powers(&self, powers: &[F]) -> Result<ExtensionAlgebra<F, D>> {
+        if self.coeffs.is_empty() {
+            ensure!(
+                powers.is_empty(),
+                "empty polynomial must be evaluated with an empty power table"
+            );
+            return Ok(ExtensionAlgebra::ZERO);
+        }
         debug_assert_eq!(self.coeffs.len(), powers.len() + 1);
         let acc = self.coeffs[0];
-        self.coeffs[1..]
+        Ok(self.coeffs[1..]
             .iter()
             .zip(powers)
-            .fold(acc, |acc, (&x, &c)| acc + x.scalar_mul(c))
+            .fold(acc, |acc, (&x, &c)| acc + x.scalar_mul(c)))
+    }
+
+    /// Evaluate the polynomial at a point given its powers. The first power is the point itself, not 1.
+    ///
+    /// This panics if the supplied power table is invalid. Use `try_eval_base_with_powers` for
+    /// untrusted inputs.
+    pub fn eval_base_with_powers(&self, powers: &[F]) -> ExtensionAlgebra<F, D> {
+        self.try_eval_base_with_powers(powers)
+            .expect("invalid polynomial power table")
     }
 }
 

--- a/field/src/polynomial/mod.rs
+++ b/field/src/polynomial/mod.rs
@@ -188,12 +188,18 @@ impl<F: Field> PolynomialCoeffs<F> {
             );
             return Ok(F::ZERO);
         }
-        debug_assert_eq!(self.coeffs.len(), powers.len() + 1);
+        let expected_powers = self.coeffs.len() - 1;
+        ensure!(
+            powers.len() == expected_powers,
+            "polynomial power table length mismatch: expected {}, got {}",
+            expected_powers,
+            powers.len()
+        );
         let acc = self.coeffs[0];
         Ok(self.coeffs[1..]
             .iter()
-            .zip(powers)
-            .fold(acc, |acc, (&x, &c)| acc + c * x))
+            .enumerate()
+            .fold(acc, |acc, (i, &c)| acc + c * powers[i]))
     }
 
     /// Evaluate the polynomial at a point given its powers. The first power is the point itself, not 1.
@@ -227,12 +233,18 @@ impl<F: Field> PolynomialCoeffs<F> {
             );
             return Ok(F::ZERO);
         }
-        debug_assert_eq!(self.coeffs.len(), powers.len() + 1);
+        let expected_powers = self.coeffs.len() - 1;
+        ensure!(
+            powers.len() == expected_powers,
+            "polynomial power table length mismatch: expected {}, got {}",
+            expected_powers,
+            powers.len()
+        );
         let acc = self.coeffs[0];
         Ok(self.coeffs[1..]
             .iter()
-            .zip(powers)
-            .fold(acc, |acc, (&x, &c)| acc + x.scalar_mul(c)))
+            .enumerate()
+            .fold(acc, |acc, (i, &c)| acc + c.scalar_mul(powers[i])))
     }
 
     /// Evaluate the polynomial at a point given its powers. The first power is the point itself, not 1.

--- a/field/src/polynomial/mod.rs
+++ b/field/src/polynomial/mod.rs
@@ -180,13 +180,29 @@ impl<F: Field> PolynomialCoeffs<F> {
     }
 
     /// Evaluate the polynomial at a point given its powers. The first power is the point itself, not 1.
-    pub fn eval_with_powers(&self, powers: &[F]) -> F {
+    pub fn try_eval_with_powers(&self, powers: &[F]) -> Result<F> {
+        if self.coeffs.is_empty() {
+            ensure!(
+                powers.is_empty(),
+                "empty polynomial must be evaluated with an empty power table"
+            );
+            return Ok(F::ZERO);
+        }
         debug_assert_eq!(self.coeffs.len(), powers.len() + 1);
         let acc = self.coeffs[0];
-        self.coeffs[1..]
+        Ok(self.coeffs[1..]
             .iter()
             .zip(powers)
-            .fold(acc, |acc, (&x, &c)| acc + c * x)
+            .fold(acc, |acc, (&x, &c)| acc + c * x))
+    }
+
+    /// Evaluate the polynomial at a point given its powers. The first power is the point itself, not 1.
+    ///
+    /// This panics if the supplied power table is invalid. Use `try_eval_with_powers` for
+    /// untrusted inputs.
+    pub fn eval_with_powers(&self, powers: &[F]) -> F {
+        self.try_eval_with_powers(powers)
+            .expect("invalid polynomial power table")
     }
 
     pub fn eval_base<const D: usize>(&self, x: F::BaseField) -> F
@@ -200,16 +216,35 @@ impl<F: Field> PolynomialCoeffs<F> {
     }
 
     /// Evaluate the polynomial at a point given its powers. The first power is the point itself, not 1.
+    pub fn try_eval_base_with_powers<const D: usize>(&self, powers: &[F::BaseField]) -> Result<F>
+    where
+        F: FieldExtension<D>,
+    {
+        if self.coeffs.is_empty() {
+            ensure!(
+                powers.is_empty(),
+                "empty polynomial must be evaluated with an empty power table"
+            );
+            return Ok(F::ZERO);
+        }
+        debug_assert_eq!(self.coeffs.len(), powers.len() + 1);
+        let acc = self.coeffs[0];
+        Ok(self.coeffs[1..]
+            .iter()
+            .zip(powers)
+            .fold(acc, |acc, (&x, &c)| acc + x.scalar_mul(c)))
+    }
+
+    /// Evaluate the polynomial at a point given its powers. The first power is the point itself, not 1.
+    ///
+    /// This panics if the supplied power table is invalid. Use `try_eval_base_with_powers` for
+    /// untrusted inputs.
     pub fn eval_base_with_powers<const D: usize>(&self, powers: &[F::BaseField]) -> F
     where
         F: FieldExtension<D>,
     {
-        debug_assert_eq!(self.coeffs.len(), powers.len() + 1);
-        let acc = self.coeffs[0];
-        self.coeffs[1..]
-            .iter()
-            .zip(powers)
-            .fold(acc, |acc, (&x, &c)| acc + x.scalar_mul(c))
+        self.try_eval_base_with_powers::<D>(powers)
+            .expect("invalid polynomial power table")
     }
 
     pub fn lde_multiple(polys: Vec<&Self>, rate_bits: usize) -> Vec<Self> {

--- a/field/src/secp256k1_base.rs
+++ b/field/src/secp256k1_base.rs
@@ -1,10 +1,8 @@
-use alloc::vec::Vec;
 use core::fmt::{self, Debug, Display, Formatter};
 use core::hash::{Hash, Hasher};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use itertools::Itertools;
 use num::bigint::BigUint;
 use num::{Integer, One};
 use serde::{Deserialize, Serialize};
@@ -122,14 +120,12 @@ impl Field for Secp256K1Base {
     }
 
     fn from_noncanonical_biguint(val: BigUint) -> Self {
-        Self(
-            val.to_u64_digits()
-                .into_iter()
-                .pad_using(4, |_| 0)
-                .collect::<Vec<_>>()[..]
-                .try_into()
-                .expect("error converting to u64 array"),
-        )
+        let reduced = val.mod_floor(&Self::order());
+        let mut limbs = [0u64; 4];
+        for (dst, limb) in limbs.iter_mut().zip(reduced.to_u64_digits()) {
+            *dst = limb;
+        }
+        Self(limbs)
     }
 
     #[inline]
@@ -269,7 +265,27 @@ impl DivAssign for Secp256K1Base {
 
 #[cfg(test)]
 mod tests {
+    use num::bigint::BigUint;
+
+    use super::Secp256K1Base;
     use crate::test_field_arithmetic;
+    use crate::types::{Field, PrimeField};
 
     test_field_arithmetic!(crate::secp256k1_base::Secp256K1Base);
+
+    #[test]
+    fn oversized_biguint_reduces_mod_order() {
+        let order = Secp256K1Base::order();
+        let oversized = (&order * BigUint::from(3u32)) + BigUint::from(42u32);
+        let reduced = Secp256K1Base::from_noncanonical_biguint(oversized);
+        assert_eq!(reduced.to_canonical_biguint(), BigUint::from(42u32));
+
+        let multiple = Secp256K1Base::from_noncanonical_biguint(&order * BigUint::from(2u32));
+        assert_eq!(multiple, Secp256K1Base::ZERO);
+
+        let extra_limb = BigUint::from(1u32) << 320usize;
+        let expected = &extra_limb % &order;
+        let reduced_extra = Secp256K1Base::from_noncanonical_biguint(extra_limb);
+        assert_eq!(reduced_extra.to_canonical_biguint(), expected);
+    }
 }

--- a/field/src/secp256k1_scalar.rs
+++ b/field/src/secp256k1_scalar.rs
@@ -1,10 +1,8 @@
-use alloc::vec::Vec;
 use core::fmt::{self, Debug, Display, Formatter};
 use core::hash::{Hash, Hasher};
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use itertools::Itertools;
 use num::bigint::BigUint;
 use num::{Integer, One};
 use serde::{Deserialize, Serialize};
@@ -130,14 +128,12 @@ impl Field for Secp256K1Scalar {
     }
 
     fn from_noncanonical_biguint(val: BigUint) -> Self {
-        Self(
-            val.to_u64_digits()
-                .into_iter()
-                .pad_using(4, |_| 0)
-                .collect::<Vec<_>>()[..]
-                .try_into()
-                .expect("error converting to u64 array"),
-        )
+        let reduced = val.mod_floor(&Self::order());
+        let mut limbs = [0u64; 4];
+        for (dst, limb) in limbs.iter_mut().zip(reduced.to_u64_digits()) {
+            *dst = limb;
+        }
+        Self(limbs)
     }
 
     #[inline]
@@ -277,7 +273,27 @@ impl DivAssign for Secp256K1Scalar {
 
 #[cfg(test)]
 mod tests {
+    use num::bigint::BigUint;
+
+    use super::Secp256K1Scalar;
     use crate::test_field_arithmetic;
+    use crate::types::{Field, PrimeField};
 
     test_field_arithmetic!(crate::secp256k1_scalar::Secp256K1Scalar);
+
+    #[test]
+    fn oversized_biguint_reduces_mod_order() {
+        let order = Secp256K1Scalar::order();
+        let oversized = (&order * BigUint::from(3u32)) + BigUint::from(42u32);
+        let reduced = Secp256K1Scalar::from_noncanonical_biguint(oversized);
+        assert_eq!(reduced.to_canonical_biguint(), BigUint::from(42u32));
+
+        let multiple = Secp256K1Scalar::from_noncanonical_biguint(&order * BigUint::from(2u32));
+        assert_eq!(multiple, Secp256K1Scalar::ZERO);
+
+        let extra_limb = BigUint::from(1u32) << 320usize;
+        let expected = &extra_limb % &order;
+        let reduced_extra = Secp256K1Scalar::from_noncanonical_biguint(extra_limb);
+        assert_eq!(reduced_extra.to_canonical_biguint(), expected);
+    }
 }

--- a/plonky2/src/batch_fri/oracle.rs
+++ b/plonky2/src/batch_fri/oracle.rs
@@ -1,5 +1,5 @@
 #[cfg(not(feature = "std"))]
-use alloc::{format, vec::Vec};
+use alloc::{format, vec, vec::Vec};
 
 use anyhow::{ensure, Result};
 use itertools::Itertools;

--- a/plonky2/src/batch_fri/verifier.rs
+++ b/plonky2/src/batch_fri/verifier.rs
@@ -10,12 +10,11 @@ use crate::fri::proof::{
     eval_final_polys_at_point, FriChallenges, FriInitialTreeProof, FriProof, FriQueryRound,
 };
 use crate::fri::structure::{FriBatchInfo, FriInstanceInfo, FriOpenings};
-use crate::fri::validate_batch_fri_auxiliary_shape;
 use crate::fri::verifier::{
     compute_evaluation, eval_opening_expression, fri_verify_proof_of_work,
     PrecomputedReducedOpenings,
 };
-use crate::fri::FriParams;
+use crate::fri::{validate_batch_fri_auxiliary_shape, FriParams};
 use crate::hash::hash_types::RichField;
 use crate::hash::merkle_proofs::{verify_batch_merkle_proof_to_cap, verify_merkle_proof_to_cap};
 use crate::hash::merkle_tree::MerkleCap;

--- a/plonky2/src/fri/mod.rs
+++ b/plonky2/src/fri/mod.rs
@@ -23,15 +23,14 @@ pub mod validate_shape;
 pub mod verifier;
 pub mod witness_util;
 
-pub use validate_shape::{
-    validate_batch_fri_auxiliary_shape, validate_batch_fri_proof_shape,
-    validate_fri_auxiliary_shape,
-};
-
 // Re-export FRI types from core
 pub use qp_plonky2_core::{
     FriBatchMaskingParams, FriChallenger, FriConfig, FriConfigObserve, FriFinalPolyLayout,
     FriParams, FriParamsObserve, FriReductionStrategy,
+};
+pub use validate_shape::{
+    validate_batch_fri_auxiliary_shape, validate_batch_fri_proof_shape,
+    validate_fri_auxiliary_shape,
 };
 
 /// Trait for observing FRI configuration in a RecursiveChallenger (circuit target version).

--- a/plonky2/src/gadgets/arithmetic.rs
+++ b/plonky2/src/gadgets/arithmetic.rs
@@ -433,6 +433,13 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Equ
         let inv = src.read_target()?;
         Ok(Self { x, y, equal, inv })
     }
+
+    fn validate(&self, common_data: &CommonCircuitData<F, D>) -> IoResult<()> {
+        crate::iop::generator::validate_target(common_data, self.x)?;
+        crate::iop::generator::validate_target(common_data, self.y)?;
+        crate::iop::generator::validate_target(common_data, self.equal.target)?;
+        crate::iop::generator::validate_target(common_data, self.inv)
+    }
 }
 
 /// Represents a base arithmetic operation in the circuit. Used to memoize results.

--- a/plonky2/src/gadgets/polynomial.rs
+++ b/plonky2/src/gadgets/polynomial.rs
@@ -1,6 +1,8 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
+use anyhow::{ensure, Result};
+
 use crate::field::extension::Extendable;
 use crate::hash::hash_types::RichField;
 use crate::iop::ext_target::{ExtensionAlgebraTarget, ExtensionTarget};
@@ -75,6 +77,33 @@ impl<const D: usize> PolynomialCoeffsExtAlgebraTarget<D> {
     }
 
     /// Evaluate the polynomial at a point given its powers. The first power is the point itself, not 1.
+    pub fn try_eval_with_powers<F>(
+        &self,
+        builder: &mut CircuitBuilder<F, D>,
+        powers: &[ExtensionAlgebraTarget<D>],
+    ) -> Result<ExtensionAlgebraTarget<D>>
+    where
+        F: RichField + Extendable<D>,
+    {
+        if self.0.is_empty() {
+            ensure!(
+                powers.is_empty(),
+                "empty polynomial must be evaluated with an empty power table"
+            );
+            return Ok(builder.zero_ext_algebra());
+        }
+        debug_assert_eq!(self.0.len(), powers.len() + 1);
+        let acc = self.0[0];
+        Ok(self.0[1..]
+            .iter()
+            .zip(powers)
+            .fold(acc, |acc, (&x, &c)| builder.mul_add_ext_algebra(c, x, acc)))
+    }
+
+    /// Evaluate the polynomial at a point given its powers. The first power is the point itself, not 1.
+    ///
+    /// This panics if the supplied power table is invalid. Use `try_eval_with_powers` for
+    /// untrusted inputs.
     pub fn eval_with_powers<F>(
         &self,
         builder: &mut CircuitBuilder<F, D>,
@@ -83,11 +112,7 @@ impl<const D: usize> PolynomialCoeffsExtAlgebraTarget<D> {
     where
         F: RichField + Extendable<D>,
     {
-        debug_assert_eq!(self.0.len(), powers.len() + 1);
-        let acc = self.0[0];
-        self.0[1..]
-            .iter()
-            .zip(powers)
-            .fold(acc, |acc, (&x, &c)| builder.mul_add_ext_algebra(c, x, acc))
+        self.try_eval_with_powers(builder, powers)
+            .expect("invalid polynomial power table")
     }
 }

--- a/plonky2/src/gadgets/polynomial.rs
+++ b/plonky2/src/gadgets/polynomial.rs
@@ -92,12 +92,17 @@ impl<const D: usize> PolynomialCoeffsExtAlgebraTarget<D> {
             );
             return Ok(builder.zero_ext_algebra());
         }
-        debug_assert_eq!(self.0.len(), powers.len() + 1);
+        let expected_powers = self.0.len() - 1;
+        ensure!(
+            powers.len() == expected_powers,
+            "polynomial power table length mismatch: expected {}, got {}",
+            expected_powers,
+            powers.len()
+        );
         let acc = self.0[0];
-        Ok(self.0[1..]
-            .iter()
-            .zip(powers)
-            .fold(acc, |acc, (&x, &c)| builder.mul_add_ext_algebra(c, x, acc)))
+        Ok(self.0[1..].iter().enumerate().fold(acc, |acc, (i, &c)| {
+            builder.mul_add_ext_algebra(c, powers[i], acc)
+        }))
     }
 
     /// Evaluate the polynomial at a point given its powers. The first power is the point itself, not 1.

--- a/plonky2/src/gadgets/range_check.rs
+++ b/plonky2/src/gadgets/range_check.rs
@@ -147,4 +147,10 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Low
             high,
         })
     }
+
+    fn validate(&self, common_data: &CommonCircuitData<F, D>) -> IoResult<()> {
+        crate::iop::generator::validate_target(common_data, self.integer)?;
+        crate::iop::generator::validate_target(common_data, self.low)?;
+        crate::iop::generator::validate_target(common_data, self.high)
+    }
 }

--- a/plonky2/src/gates/reducing.rs
+++ b/plonky2/src/gates/reducing.rs
@@ -8,6 +8,7 @@ use alloc::{
 use core::ops::Range;
 
 use anyhow::Result;
+use qp_plonky2_core::circuit_config::reducing_base_capacity;
 
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::gates::gate::Gate;
@@ -21,7 +22,6 @@ use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::{Buffer, IoResult, Read, Write};
-use qp_plonky2_core::circuit_config::reducing_base_capacity;
 
 /// Computes `sum alpha^i c_i` for a vector `c_i` of `num_coeffs` elements of the base field.
 #[derive(Debug, Default, Clone)]

--- a/plonky2/src/gates/reducing_extension.rs
+++ b/plonky2/src/gates/reducing_extension.rs
@@ -8,6 +8,7 @@ use alloc::{
 use core::ops::Range;
 
 use anyhow::Result;
+use qp_plonky2_core::circuit_config::reducing_extension_capacity;
 
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::gates::gate::Gate;
@@ -21,7 +22,6 @@ use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::{Buffer, IoResult, Read, Write};
-use qp_plonky2_core::circuit_config::reducing_extension_capacity;
 
 /// Computes `sum alpha^i c_i` for a vector `c_i` of `num_coeffs` elements of the extension field.
 #[derive(Debug, Clone, Default)]

--- a/plonky2/src/gates/selectors.rs
+++ b/plonky2/src/gates/selectors.rs
@@ -7,7 +7,6 @@
 use alloc::{vec, vec::Vec};
 
 use hashbrown::HashMap;
-
 // Re-export selector types from core
 pub use qp_plonky2_core::selectors::{LookupSelectors, SelectorsInfo, UNUSED_SELECTOR};
 

--- a/plonky2/src/iop/generator.rs
+++ b/plonky2/src/iop/generator.rs
@@ -44,6 +44,8 @@ pub fn generate_partial_witness<
     );
 
     for (t, v) in inputs.target_values.into_iter() {
+        validate_target(common_data, t)
+            .map_err(|_| anyhow!("witness target {:?} is outside the circuit domain", t))?;
         witness.set_target(t, v)?;
     }
 
@@ -76,6 +78,12 @@ pub fn generate_partial_witness<
             // targets' representatives.
             let mut new_target_reps = Vec::with_capacity(buffer.target_values.len());
             for (t, v) in buffer.target_values.drain(..) {
+                validate_target(common_data, t).map_err(|_| {
+                    anyhow!(
+                        "generated witness target {:?} is outside the circuit domain",
+                        t
+                    )
+                })?;
                 let reps = witness.set_target_returning_rep(t, v)?;
                 new_target_reps.extend(reps);
             }

--- a/plonky2/src/iop/generator.rs
+++ b/plonky2/src/iop/generator.rs
@@ -19,7 +19,7 @@ use crate::iop::wire::Wire;
 use crate::iop::witness::{PartialWitness, PartitionWitness, Witness, WitnessWrite};
 use crate::plonk::circuit_data::{CommonCircuitData, ProverOnlyCircuitData};
 use crate::plonk::config::GenericConfig;
-use crate::util::serialization::{Buffer, IoResult, Read, Write};
+use crate::util::serialization::{Buffer, IoError, IoResult, Read, Write};
 
 /// Given a `PartitionWitness` that has only inputs set, populates the rest of the witness using the
 /// given set of generators.
@@ -231,6 +231,48 @@ pub trait SimpleGenerator<F: RichField + Extendable<D>, const D: usize>:
     fn deserialize(src: &mut Buffer, common_data: &CommonCircuitData<F, D>) -> IoResult<Self>
     where
         Self: Sized;
+
+    fn validate(&self, common_data: &CommonCircuitData<F, D>) -> IoResult<()> {
+        for target in self.dependencies() {
+            validate_target(common_data, target)?;
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn checked_degree<F: RichField + Extendable<D>, const D: usize>(
+    common_data: &CommonCircuitData<F, D>,
+) -> IoResult<usize> {
+    1usize
+        .checked_shl(
+            common_data
+                .trace_degree_bits
+                .try_into()
+                .unwrap_or(usize::BITS),
+        )
+        .ok_or(IoError)
+}
+
+pub(crate) fn validate_wire_coordinates<F: RichField + Extendable<D>, const D: usize>(
+    common_data: &CommonCircuitData<F, D>,
+    row: usize,
+    column: usize,
+) -> IoResult<()> {
+    let degree = checked_degree(common_data)?;
+    if row >= degree || column >= common_data.config.num_wires {
+        return Err(IoError);
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_target<F: RichField + Extendable<D>, const D: usize>(
+    common_data: &CommonCircuitData<F, D>,
+    target: Target,
+) -> IoResult<()> {
+    match target {
+        Target::Wire(Wire { row, column }) => validate_wire_coordinates(common_data, row, column),
+        Target::VirtualTarget { .. } => Ok(()),
+    }
 }
 
 #[derive(Debug)]
@@ -267,8 +309,10 @@ impl<F: RichField + Extendable<D>, SG: SimpleGenerator<F, D>, const D: usize> Wi
     }
 
     fn deserialize(src: &mut Buffer, common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
+        let inner = SG::deserialize(src, common_data)?;
+        inner.validate(common_data)?;
         Ok(Self {
-            inner: SG::deserialize(src, common_data)?,
+            inner,
             _phantom: PhantomData,
         })
     }
@@ -309,6 +353,11 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Cop
         let dst = source.read_target()?;
         Ok(Self { src, dst })
     }
+
+    fn validate(&self, common_data: &CommonCircuitData<F, D>) -> IoResult<()> {
+        validate_target(common_data, self.src)?;
+        validate_target(common_data, self.dst)
+    }
 }
 
 /// A generator for including a random value
@@ -344,6 +393,10 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Ran
     fn deserialize(src: &mut Buffer, _common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
         let target = src.read_target()?;
         Ok(Self { target })
+    }
+
+    fn validate(&self, common_data: &CommonCircuitData<F, D>) -> IoResult<()> {
+        validate_target(common_data, self.target)
     }
 }
 
@@ -388,6 +441,11 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Non
         let to_test = src.read_target()?;
         let dummy = src.read_target()?;
         Ok(Self { to_test, dummy })
+    }
+
+    fn validate(&self, common_data: &CommonCircuitData<F, D>) -> IoResult<()> {
+        validate_target(common_data, self.to_test)?;
+        validate_target(common_data, self.dummy)
     }
 }
 
@@ -441,5 +499,12 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Con
             wire_index,
             constant,
         })
+    }
+
+    fn validate(&self, common_data: &CommonCircuitData<F, D>) -> IoResult<()> {
+        if self.constant_index >= common_data.config.num_constants {
+            return Err(IoError);
+        }
+        validate_wire_coordinates(common_data, self.row, self.wire_index)
     }
 }

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -818,10 +818,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         inputs: &[u16],
     ) -> Result<usize, &'static str> {
         let lut = Arc::new(Self::get_lut_from_fn::<u16>(f, inputs));
-        if lut.is_empty() {
-            return Err("lookup table must not be empty");
-        }
-        Ok(self.insert_lookup_table(lut))
+        self.try_update_luts_from_pairs(lut)
     }
 
     /// Given a function `f: fn(u16) -> u16`, adds a LUT to the circuit builder.
@@ -848,7 +845,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             .zip_eq(table.iter().copied())
             .collect();
         let lut: LookupTable = Arc::new(pairs);
-        Ok(self.insert_lookup_table(lut))
+        self.try_update_luts_from_pairs(lut)
     }
 
     /// Adds a table to the vector of LUTs in the circuit builder, given a list of inputs and table values.
@@ -862,6 +859,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         &mut self,
         table: LookupTable,
     ) -> Result<usize, &'static str> {
+        self.config.check_lookup_widths()?;
         if table.is_empty() {
             return Err("lookup table must not be empty");
         }

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -1,7 +1,7 @@
 //! Logic for building plonky2 circuits.
 
 #[cfg(not(feature = "std"))]
-use alloc::{collections::BTreeMap, sync::Arc, vec, vec::Vec};
+use alloc::{collections::BTreeMap, string::String, sync::Arc, vec, vec::Vec};
 use core::cmp::max;
 #[cfg(feature = "std")]
 use std::{collections::BTreeMap, sync::Arc};

--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -369,6 +369,60 @@ pub struct ProverOnlyCircuitData<
 impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     ProverOnlyCircuitData<F, C, D>
 {
+    pub fn check_internal_maps(&self, common_data: &CommonCircuitData<F, D>) -> Result<()> {
+        let degree = 1usize
+            .checked_shl(common_data.degree_bits().try_into().unwrap_or(usize::BITS))
+            .ok_or_else(|| anyhow::anyhow!("prover metadata degree bits exceed usize width"))?;
+        let num_wires = common_data.config.num_wires;
+        let wire_targets = degree
+            .checked_mul(num_wires)
+            .ok_or_else(|| anyhow::anyhow!("prover wire target count overflow"))?;
+        let representative_len = self.representative_map.len();
+
+        ensure!(
+            representative_len >= wire_targets,
+            "representative map is shorter than the wire target domain"
+        );
+        for (index, &representative) in self.representative_map.iter().enumerate() {
+            ensure!(
+                representative < representative_len,
+                "representative map entry {index} points out of range"
+            );
+            ensure!(
+                self.representative_map[representative] == representative,
+                "representative map entry {index} does not point to a root"
+            );
+        }
+
+        for &target in &self.public_inputs {
+            prover_target_index(target, num_wires, degree, representative_len)?;
+        }
+
+        let mut expected_generator_indices_by_watches = BTreeMap::new();
+        for (generator_index, generator) in self.generators.iter().enumerate() {
+            for watch in generator.0.watch_list() {
+                let watch_index =
+                    prover_target_index(watch, num_wires, degree, representative_len)?;
+                let watch_representative = self.representative_map[watch_index];
+                expected_generator_indices_by_watches
+                    .entry(watch_representative)
+                    .or_insert_with(Vec::new)
+                    .push(generator_index);
+            }
+        }
+        for indices in expected_generator_indices_by_watches.values_mut() {
+            indices.dedup();
+            indices.shrink_to_fit();
+        }
+
+        ensure!(
+            self.generator_indices_by_watches == expected_generator_indices_by_watches,
+            "generator watch index map does not match deserialized generators"
+        );
+
+        Ok(())
+    }
+
     pub fn check_lookup_metadata(&self, common_data: &CommonCircuitData<F, D>) -> Result<()> {
         let degree = 1usize
             .checked_shl(common_data.degree_bits().try_into().unwrap_or(usize::BITS))
@@ -468,8 +522,8 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
             );
 
             for &(input, output) in lookups {
-                validate_prover_target(input, num_wires, degree, self.representative_map.len())?;
-                validate_prover_target(output, num_wires, degree, self.representative_map.len())?;
+                prover_target_index(input, num_wires, degree, self.representative_map.len())?;
+                prover_target_index(output, num_wires, degree, self.representative_map.len())?;
             }
         }
 
@@ -496,12 +550,12 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     }
 }
 
-fn validate_prover_target(
+fn prover_target_index(
     target: Target,
     num_wires: usize,
     degree: usize,
     representative_len: usize,
-) -> Result<()> {
+) -> Result<usize> {
     let index = match target {
         Target::Wire(wire) => {
             ensure!(wire.row < degree, "wire target row is outside the trace");
@@ -524,7 +578,7 @@ fn validate_prover_target(
         "prover target index is outside the representative map"
     );
 
-    Ok(())
+    Ok(index)
 }
 
 /// Circuit data required by the verifier, but not the prover.

--- a/plonky2/src/plonk/config.rs
+++ b/plonky2/src/plonk/config.rs
@@ -7,6 +7,8 @@
 //! mixing Poseidon internally and truncated Keccak externally.
 
 // Re-export core config types - these are the canonical definitions
+use alloc::vec::Vec;
+
 pub use qp_plonky2_core::config::{
     merkle_node_hash_input, GenericConfig, GenericHashOut, Hasher, KeccakGoldilocksConfig,
     PoseidonGoldilocksConfig, MERKLE_LEAF_DOMAIN_TAG, MERKLE_NODE_DOMAIN_TAG,

--- a/plonky2/src/plonk/config.rs
+++ b/plonky2/src/plonk/config.rs
@@ -7,6 +7,7 @@
 //! mixing Poseidon internally and truncated Keccak externally.
 
 // Re-export core config types - these are the canonical definitions
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 pub use qp_plonky2_core::config::{

--- a/plonky2/src/util/serialization/generator_serialization.rs
+++ b/plonky2/src/util/serialization/generator_serialization.rs
@@ -37,6 +37,7 @@ macro_rules! read_generator_impl {
         $(if tag == i.next().unwrap() {
         let generator =
             <$generator_types as $crate::iop::generator::SimpleGenerator<F, D>>::deserialize(buf, $common)?;
+        $crate::iop::generator::SimpleGenerator::<F, D>::validate(&generator, $common)?;
         Ok($crate::iop::generator::WitnessGeneratorRef::<F, D>::new(
             $crate::iop::generator::SimpleGenerator::<F, D>::adapter(generator),
         ))

--- a/plonky2/src/util/serialization/mod.rs
+++ b/plonky2/src/util/serialization/mod.rs
@@ -1068,6 +1068,9 @@ pub trait Read {
             lut_to_lookups,
         };
         prover_only
+            .check_internal_maps(common_data)
+            .map_err(|_| IoError)?;
+        prover_only
             .check_lookup_metadata(common_data)
             .map_err(|_| IoError)?;
 

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -1,6 +1,7 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use hashbrown::HashMap;
+use num::bigint::BigUint;
 use plonky2::batch_fri::oracle::BatchFriOracle;
 use plonky2::batch_fri::prover::batch_fri_proof;
 use plonky2::batch_fri::verifier::verify_batch_fri_proof;
@@ -10,7 +11,9 @@ use plonky2::field::interpolation::{try_barycentric_weights, try_interpolant, tr
 use plonky2::field::packable::Packable;
 use plonky2::field::packed::PackedField;
 use plonky2::field::polynomial::{PolynomialCoeffs, PolynomialValues};
-use plonky2::field::types::Field;
+use plonky2::field::secp256k1_base::Secp256K1Base;
+use plonky2::field::secp256k1_scalar::Secp256K1Scalar;
+use plonky2::field::types::{Field, PrimeField};
 use plonky2::field::zero_poly_coset::ZeroPolyOnCoset;
 use plonky2::fri::proof::{
     FriChallenges, FriFinalPolys, FriFinalPolysTarget, FriInitialTreeProof, FriProof,
@@ -610,6 +613,45 @@ fn power_table_length_mismatch_rejected() {
     assert!(target_poly
         .try_eval_with_powers(&mut builder, &target_powers[..1])
         .is_err());
+}
+
+#[test]
+fn secp256k1_biguint_constructors_reduce_oversized_inputs() {
+    let base_order = Secp256K1Base::order();
+    let base_oversized = (&base_order * BigUint::from(5u32)) + BigUint::from(17u32);
+    let base_result = catch_unwind(AssertUnwindSafe(|| {
+        Secp256K1Base::from_noncanonical_biguint(base_oversized)
+    }));
+    assert!(
+        base_result.is_ok(),
+        "oversized base-field BigUint must not panic"
+    );
+    assert_eq!(
+        base_result.unwrap().to_canonical_biguint(),
+        BigUint::from(17u32)
+    );
+    assert_eq!(
+        Secp256K1Base::from_noncanonical_biguint(&base_order * BigUint::from(2u32)),
+        Secp256K1Base::ZERO
+    );
+
+    let scalar_order = Secp256K1Scalar::order();
+    let scalar_oversized = (&scalar_order * BigUint::from(7u32)) + BigUint::from(29u32);
+    let scalar_result = catch_unwind(AssertUnwindSafe(|| {
+        Secp256K1Scalar::from_noncanonical_biguint(scalar_oversized)
+    }));
+    assert!(
+        scalar_result.is_ok(),
+        "oversized scalar-field BigUint must not panic"
+    );
+    assert_eq!(
+        scalar_result.unwrap().to_canonical_biguint(),
+        BigUint::from(29u32)
+    );
+    assert_eq!(
+        Secp256K1Scalar::from_noncanonical_biguint(&scalar_order * BigUint::from(2u32)),
+        Secp256K1Scalar::ZERO
+    );
 }
 
 #[test]

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -1864,6 +1864,33 @@ fn short_merkle_leaves_are_length_bound() -> anyhow::Result<()> {
 }
 
 #[test]
+fn merkle_leaf_commitments_length_bind_payloads() -> anyhow::Result<()> {
+    let leaf = vec![F::from_canonical_u64(1), F::from_canonical_u64(2)];
+    let mut zero_extended_leaf = leaf.clone();
+    zero_extended_leaf.push(F::ZERO);
+
+    let leaf_hash = PoseidonHash::hash_merkle_leaf(&leaf);
+    let extended_hash = PoseidonHash::hash_merkle_leaf(&zero_extended_leaf);
+    assert_ne!(leaf_hash, extended_hash);
+
+    let leaves = vec![
+        leaf.clone(),
+        vec![F::from_canonical_u64(3), F::from_canonical_u64(4)],
+    ];
+    let tree = MerkleTree::<F, PoseidonHash>::new(leaves, 0);
+    let proof = tree.prove(0);
+    verify_merkle_proof_to_cap(leaf, 0, &tree.cap, &proof)?;
+    assert!(verify_merkle_proof_to_cap(zero_extended_leaf, 0, &tree.cap, &proof).is_err());
+
+    let internal_node = PoseidonHash::two_to_one(leaf_hash, extended_hash);
+    assert_ne!(
+        PoseidonHash::hash_merkle_leaf(&internal_node.elements),
+        internal_node
+    );
+    Ok(())
+}
+
+#[test]
 fn trailing_zero_hash_len_delimited_distinguishes_lengths() {
     type P = <PoseidonHash as Hasher<F>>::Permutation;
 

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -2050,6 +2050,39 @@ fn short_fri_opening_batches_rejected() {
 }
 
 #[test]
+fn commit_phase_cap_count_rejected() {
+    let (params, instance, openings, challenges, initial_merkle_caps, mut extra_cap_proof) =
+        minimal_fri_auxiliary_case();
+    extra_cap_proof
+        .commit_phase_merkle_caps
+        .push(initial_merkle_caps[0].clone());
+
+    assert!(validate_fri_auxiliary_shape::<F, C, D>(
+        &instance,
+        &openings,
+        &challenges,
+        &initial_merkle_caps,
+        &extra_cap_proof,
+        &params,
+    )
+    .is_err());
+
+    let (mut params, instance, openings, challenges, initial_merkle_caps, proof) =
+        minimal_fri_auxiliary_case();
+    params.reduction_arity_bits = vec![1];
+
+    assert!(validate_fri_auxiliary_shape::<F, C, D>(
+        &instance,
+        &openings,
+        &challenges,
+        &initial_merkle_caps,
+        &proof,
+        &params,
+    )
+    .is_err());
+}
+
+#[test]
 fn valid_fri_auxiliary_shapes_pass() {
     let (params, instance, openings, challenges, initial_merkle_caps, proof) =
         minimal_fri_auxiliary_case();

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -1618,6 +1618,33 @@ fn empty_lookup_tables_rejected() {
 }
 
 #[test]
+fn zero_lookup_slot_counts_rejected() -> anyhow::Result<()> {
+    let mut narrow_config = CircuitConfig::standard_recursion_config();
+    narrow_config.num_routed_wires = 2;
+    assert!(narrow_config.check_lookup_widths().is_err());
+    assert!(catch_unwind(AssertUnwindSafe(|| {
+        let _ = CircuitBuilder::<F, D>::new(narrow_config);
+    }))
+    .is_err());
+
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let input = builder.add_virtual_target();
+    let table_index = builder
+        .try_add_lookup_table_from_pairs(std::sync::Arc::new(vec![(0u16, 10u16), (1u16, 11u16)]))
+        .unwrap();
+    let output = builder.add_lookup_from_index(input, table_index);
+    builder.register_public_input(output);
+
+    let data = builder.build::<C>();
+    let mut pw = PartialWitness::new();
+    pw.set_target(input, F::ONE)?;
+    let proof = data.prove(pw)?;
+    assert_eq!(proof.public_inputs, vec![F::from_canonical_u16(11)]);
+    data.verify(proof)
+}
+
+#[test]
 fn merkle_poseidon_zero_suffix_leaf_collision_rejected() -> anyhow::Result<()> {
     let leaf = vec![
         F::from_canonical_u64(1),

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -568,6 +568,51 @@ fn empty_polynomial_fast_path_returns_zero_or_err() {
 }
 
 #[test]
+fn power_table_length_mismatch_rejected() {
+    let poly = PolynomialCoeffs::<F>::new(vec![F::ONE, F::ONE, F::ONE]);
+    let powers = [F::TWO, F::TWO * F::TWO];
+    assert_eq!(
+        poly.try_eval_with_powers(&powers).unwrap(),
+        F::ONE + F::TWO + F::TWO * F::TWO
+    );
+    assert!(poly.try_eval_with_powers(&powers[..1]).is_err());
+    assert!(poly
+        .try_eval_with_powers(&[powers[0], powers[1], powers[1] * F::TWO])
+        .is_err());
+    assert!(catch_unwind(AssertUnwindSafe(|| poly.eval_with_powers(&powers[..1]))).is_err());
+
+    let ext_poly = PolynomialCoeffs::<FF>::new(vec![FF::ONE, FF::ONE, FF::ONE]);
+    assert!(ext_poly
+        .try_eval_base_with_powers::<D>(&powers[..1])
+        .is_err());
+
+    let algebra_poly = PolynomialCoeffsAlgebra::<FF, D>::new(vec![
+        ExtensionAlgebra::<FF, D>::one(),
+        ExtensionAlgebra::<FF, D>::one(),
+        ExtensionAlgebra::<FF, D>::one(),
+    ]);
+    let algebra_powers = [
+        ExtensionAlgebra::<FF, D>::one(),
+        ExtensionAlgebra::<FF, D>::one(),
+    ];
+    assert!(algebra_poly
+        .try_eval_with_powers(&algebra_powers[..1])
+        .is_err());
+    assert!(algebra_poly.try_eval_base_with_powers(&[FF::ONE]).is_err());
+
+    let mut builder = CircuitBuilder::<F, D>::new(CircuitConfig::standard_recursion_config());
+    let one = builder.constant_ext_algebra(ExtensionAlgebra::<FF, D>::one());
+    let target_poly = PolynomialCoeffsExtAlgebraTarget::<D>(vec![one, one, one]);
+    let target_powers = [one, one];
+    assert!(target_poly
+        .try_eval_with_powers(&mut builder, &target_powers)
+        .is_ok());
+    assert!(target_poly
+        .try_eval_with_powers(&mut builder, &target_powers[..1])
+        .is_err());
+}
+
+#[test]
 fn zero_poly_on_coset_rejects_unsupported_domains() {
     assert!(ZeroPolyOnCoset::<F>::try_new(1, F::TWO_ADICITY + 1).is_err());
     assert!(ZeroPolyOnCoset::<F>::try_new(F::TWO_ADICITY, 1).is_err());

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -19,11 +19,11 @@ use plonky2::fri::proof::{
     FriChallenges, FriFinalPolys, FriFinalPolysTarget, FriInitialTreeProof, FriProof,
     FriProofTarget, FriQueryRound,
 };
+use plonky2::fri::structure::{
+    FriBatchInfo, FriInstanceInfo, FriOpeningBatch, FriOpeningExpression, FriOpenings,
+    FriOracleInfo, FriPolynomialInfo,
+};
 use plonky2::fri::{
-    structure::{
-        FriBatchInfo, FriInstanceInfo, FriOpeningBatch, FriOpeningExpression, FriOpenings,
-        FriOracleInfo, FriPolynomialInfo,
-    },
     validate_batch_fri_auxiliary_shape, validate_fri_auxiliary_shape, FriBatchMaskingParams,
     FriChallenger, FriConfig, FriFinalPolyLayout, FriParams, FriReductionStrategy,
 };

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -512,6 +512,18 @@ fn generator_deserialization_bounds_rejected() {
 }
 
 #[test]
+fn unvalidated_witness_targets_return_err() {
+    let data = simple_circuit_data();
+    let mut pw = PartialWitness::new();
+    pw.set_target(Target::wire(data.common.degree(), 0), F::ONE)
+        .unwrap();
+
+    let result = catch_unwind(AssertUnwindSafe(|| data.prove(pw)));
+    assert!(result.is_ok(), "invalid witness target must not panic");
+    assert!(result.unwrap().is_err());
+}
+
+#[test]
 fn zero_poly_on_coset_rejects_unsupported_domains() {
     assert!(ZeroPolyOnCoset::<F>::try_new(1, F::TWO_ADICITY + 1).is_err());
     assert!(ZeroPolyOnCoset::<F>::try_new(F::TWO_ADICITY, 1).is_err());

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -56,7 +56,7 @@ use plonky2::iop::target::Target;
 use plonky2::iop::witness::{PartialWitness, Witness, WitnessWrite};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::circuit_data::{
-    CircuitConfig, CommonCircuitData, ProverOnlyCircuitData, VerifierCircuitTarget,
+    CircuitConfig, CircuitData, CommonCircuitData, ProverOnlyCircuitData, VerifierCircuitTarget,
 };
 use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher, PoseidonGoldilocksConfig};
 use plonky2::plonk::plonk_common::PlonkOracle;
@@ -473,6 +473,80 @@ fn valid_fft_root_table_roundtrip_recomputes() {
         ProverOnlyCircuitData::<F, C, D>::from_bytes(&bytes, &serializer, &data.common).unwrap();
 
     assert!(decoded.fft_root_table.is_some());
+}
+
+fn prover_data_with_generator() -> (CircuitData<F, C, D>, Target) {
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let x = builder.add_virtual_target();
+    let (low, _high) = builder.split_low_high(x, 3, 6);
+    builder.register_public_input(low);
+    (builder.build::<C>(), x)
+}
+
+#[test]
+fn unvalidated_prover_data_internal_maps_rejected() -> anyhow::Result<()> {
+    let serializer = DefaultGeneratorSerializer::<C, D>::default();
+    let (data, x) = prover_data_with_generator();
+
+    let bytes = data
+        .prover_only
+        .to_bytes(&serializer, &data.common)
+        .unwrap();
+    let decoded =
+        ProverOnlyCircuitData::<F, C, D>::from_bytes(&bytes, &serializer, &data.common).unwrap();
+    let roundtrip = CircuitData {
+        prover_only: decoded,
+        verifier_only: data.verifier_only.clone(),
+        common: data.common.clone(),
+    };
+    let mut pw = PartialWitness::new();
+    pw.set_target(x, F::from_canonical_u64(45))?;
+    let proof = roundtrip.prove(pw)?;
+    roundtrip.verify(proof)?;
+
+    let (mut bad_representative_len, _) = prover_data_with_generator();
+    bad_representative_len
+        .prover_only
+        .representative_map
+        .clear();
+    let bytes = bad_representative_len
+        .prover_only
+        .to_bytes(&serializer, &bad_representative_len.common)
+        .unwrap();
+    assert!(ProverOnlyCircuitData::<F, C, D>::from_bytes(
+        &bytes,
+        &serializer,
+        &bad_representative_len.common
+    )
+    .is_err());
+
+    let (mut bad_representative_root, _) = prover_data_with_generator();
+    bad_representative_root.prover_only.representative_map[0] =
+        bad_representative_root.prover_only.representative_map.len();
+    let bytes = bad_representative_root
+        .prover_only
+        .to_bytes(&serializer, &bad_representative_root.common)
+        .unwrap();
+    assert!(ProverOnlyCircuitData::<F, C, D>::from_bytes(
+        &bytes,
+        &serializer,
+        &bad_representative_root.common
+    )
+    .is_err());
+
+    let (mut bad_watches, _) = prover_data_with_generator();
+    bad_watches.prover_only.generator_indices_by_watches.clear();
+    let bytes = bad_watches
+        .prover_only
+        .to_bytes(&serializer, &bad_watches.common)
+        .unwrap();
+    assert!(
+        ProverOnlyCircuitData::<F, C, D>::from_bytes(&bytes, &serializer, &bad_watches.common)
+            .is_err()
+    );
+
+    Ok(())
 }
 
 #[test]

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -62,8 +62,8 @@ use plonky2::recursion::cyclic_recursion::check_cyclic_proof_verifier_data;
 use plonky2::recursion::dummy_circuit::{try_cyclic_base_proof, try_dummy_circuit};
 use plonky2::util::reducing::ReducingFactorTarget;
 use plonky2::util::serialization::{
-    Buffer, DefaultGateSerializer, DefaultGeneratorSerializer, IoResult, Write,
-    MAX_DESERIALIZED_MERKLE_CAP_LEN,
+    Buffer, DefaultGateSerializer, DefaultGeneratorSerializer, IoResult,
+    WitnessGeneratorSerializer, Write, MAX_DESERIALIZED_MERKLE_CAP_LEN,
 };
 use plonky2::util::strided_view::PackedStridedView;
 use plonky2::util::timing::TimingTree;
@@ -468,6 +468,47 @@ fn valid_fft_root_table_roundtrip_recomputes() {
         ProverOnlyCircuitData::<F, C, D>::from_bytes(&bytes, &serializer, &data.common).unwrap();
 
     assert!(decoded.fft_root_table.is_some());
+}
+
+#[test]
+fn generator_deserialization_bounds_rejected() {
+    const CONSTANT_GENERATOR_TAG: u32 = 4;
+
+    let data = simple_circuit_data();
+    let serializer = DefaultGeneratorSerializer::<C, D>::default();
+
+    let mut valid = Vec::new();
+    valid.write_u32(CONSTANT_GENERATOR_TAG).unwrap();
+    valid.write_usize(0).unwrap();
+    valid.write_usize(0).unwrap();
+    valid.write_usize(0).unwrap();
+    valid.write_field(F::ONE).unwrap();
+    let mut valid_buffer = Buffer::new(&valid);
+    assert!(serializer
+        .read_generator(&mut valid_buffer, &data.common)
+        .is_ok());
+
+    let mut bad_row = Vec::new();
+    bad_row.write_u32(CONSTANT_GENERATOR_TAG).unwrap();
+    bad_row.write_usize(data.common.degree()).unwrap();
+    bad_row.write_usize(0).unwrap();
+    bad_row.write_usize(0).unwrap();
+    bad_row.write_field(F::ONE).unwrap();
+    let mut bad_row_buffer = Buffer::new(&bad_row);
+    assert!(serializer
+        .read_generator(&mut bad_row_buffer, &data.common)
+        .is_err());
+
+    let mut bad_wire = Vec::new();
+    bad_wire.write_u32(CONSTANT_GENERATOR_TAG).unwrap();
+    bad_wire.write_usize(0).unwrap();
+    bad_wire.write_usize(0).unwrap();
+    bad_wire.write_usize(data.common.config.num_wires).unwrap();
+    bad_wire.write_field(F::ONE).unwrap();
+    let mut bad_wire_buffer = Buffer::new(&bad_wire);
+    assert!(serializer
+        .read_generator(&mut bad_wire_buffer, &data.common)
+        .is_err());
 }
 
 #[test]

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -5,6 +5,7 @@ use plonky2::batch_fri::oracle::BatchFriOracle;
 use plonky2::batch_fri::prover::batch_fri_proof;
 use plonky2::batch_fri::verifier::verify_batch_fri_proof;
 use plonky2::field::cosets::{get_unique_coset_shifts, try_get_unique_coset_shifts};
+use plonky2::field::extension::algebra::{ExtensionAlgebra, PolynomialCoeffsAlgebra};
 use plonky2::field::interpolation::{try_barycentric_weights, try_interpolant, try_interpolate2};
 use plonky2::field::packable::Packable;
 use plonky2::field::packed::PackedField;
@@ -23,6 +24,7 @@ use plonky2::fri::{
     validate_batch_fri_auxiliary_shape, validate_fri_auxiliary_shape, FriBatchMaskingParams,
     FriChallenger, FriConfig, FriFinalPolyLayout, FriParams, FriReductionStrategy,
 };
+use plonky2::gadgets::polynomial::PolynomialCoeffsExtAlgebraTarget;
 use plonky2::gates::arithmetic_base::ArithmeticGate;
 use plonky2::gates::arithmetic_extension::ArithmeticExtensionGate;
 use plonky2::gates::coset_interpolation::CosetInterpolationGate;
@@ -521,6 +523,48 @@ fn unvalidated_witness_targets_return_err() {
     let result = catch_unwind(AssertUnwindSafe(|| data.prove(pw)));
     assert!(result.is_ok(), "invalid witness target must not panic");
     assert!(result.unwrap().is_err());
+}
+
+#[test]
+fn empty_polynomial_fast_path_returns_zero_or_err() {
+    let empty = PolynomialCoeffs::<F>::empty();
+    assert_eq!(empty.try_eval_with_powers(&[]).unwrap(), F::ZERO);
+    assert!(empty.try_eval_with_powers(&[F::ONE]).is_err());
+
+    let empty_ext = PolynomialCoeffs::<FF>::empty();
+    assert_eq!(
+        empty_ext.try_eval_base_with_powers::<D>(&[]).unwrap(),
+        FF::ZERO
+    );
+    assert!(empty_ext.try_eval_base_with_powers::<D>(&[F::ONE]).is_err());
+
+    let empty_algebra = PolynomialCoeffsAlgebra::<FF, D>::new(Vec::new());
+    assert_eq!(
+        empty_algebra
+            .try_eval_with_powers(&[])
+            .unwrap()
+            .to_basefield_array(),
+        ExtensionAlgebra::<FF, D>::ZERO.to_basefield_array()
+    );
+    assert!(empty_algebra
+        .try_eval_with_powers(&[ExtensionAlgebra::<FF, D>::one()])
+        .is_err());
+    assert_eq!(
+        empty_algebra
+            .try_eval_base_with_powers(&[])
+            .unwrap()
+            .to_basefield_array(),
+        ExtensionAlgebra::<FF, D>::ZERO.to_basefield_array()
+    );
+    assert!(empty_algebra.try_eval_base_with_powers(&[FF::ONE]).is_err());
+
+    let mut builder = CircuitBuilder::<F, D>::new(CircuitConfig::standard_recursion_config());
+    let empty_target = PolynomialCoeffsExtAlgebraTarget::<D>(Vec::new());
+    assert!(empty_target.try_eval_with_powers(&mut builder, &[]).is_ok());
+    let zero_power = builder.zero_ext_algebra();
+    assert!(empty_target
+        .try_eval_with_powers(&mut builder, &[zero_power])
+        .is_err());
 }
 
 #[test]

--- a/verifier/src/gates/reducing.rs
+++ b/verifier/src/gates/reducing.rs
@@ -2,6 +2,8 @@
 use alloc::{format, string::String, vec::Vec};
 use core::ops::Range;
 
+use qp_plonky2_core::circuit_config::reducing_base_capacity;
+
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::gates::gate::VerificationGate;
 use crate::gates::util::StridedConstraintConsumer;
@@ -9,7 +11,6 @@ use crate::hash::hash_types::RichField;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::vars::{EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::{Buffer, IoResult, Read, Write};
-use qp_plonky2_core::circuit_config::reducing_base_capacity;
 
 /// Computes `sum alpha^i c_i` for a vector `c_i` of `num_coeffs` elements of the base field.
 #[derive(Debug, Default, Clone)]

--- a/verifier/src/gates/reducing_extension.rs
+++ b/verifier/src/gates/reducing_extension.rs
@@ -2,6 +2,8 @@
 use alloc::{format, string::String, vec::Vec};
 use core::ops::Range;
 
+use qp_plonky2_core::circuit_config::reducing_extension_capacity;
+
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::gates::gate::VerificationGate;
 use crate::gates::util::StridedConstraintConsumer;
@@ -9,7 +11,6 @@ use crate::hash::hash_types::RichField;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::vars::{EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::{Buffer, IoResult, Read, Write};
-use qp_plonky2_core::circuit_config::reducing_extension_capacity;
 
 /// Computes `sum alpha^i c_i` for a vector `c_i` of `num_coeffs` elements of the extension field.
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
## V12 audit (10/10): medium deserialization, lookup-slot & polynomial validation

Part of the stack splitting #38 into reviewable slices. Stacked on `v12-audit/09-medium-merkle-proof-hashing`.

Addresses **9** V12 audit finding(s):

| Finding | Severity | Title | Commit |
|---|---|---|---|
| #64715 | Medium | Zero lookup slot counts cause deterministic build panics | `864969db` |
| #64717 | Medium | Missing commit-phase cap count check causes verifier panic (regression test coverage) | `3e425ad8` |
| #64718 | Medium | Generator deserialization lacks bounds checks for witness coordinates | `caf9dc2d` |
| #64719 | Medium | Unvalidated witness targets can panic the prover | `13227feb` |
| #64720 | Medium | Empty polynomial coefficients cause release-mode panics | `0f0a1288` |
| #64721 | Medium | Power-table length mismatches silently truncate polynomial evaluation | `1a64dad7` |
| #64722 | Medium | secp256k1 field bigint constructors panic on oversized inputs | `3dbfa152` |
| #64725 | Medium | Merkle leaf commitments do not uniquely bind leaf contents | `783cb705` |
| #64726 | Medium | Unvalidated prover-data deserialization causes witness-generation panics | `0d3afd72` |

---

<details>
<summary><b>#64715 · Medium · Zero lookup slot counts cause deterministic build panics</b></summary>

**Targets**
- CircuitBuilder::check_config
- LookupGate::num_slots
- LookupTableGate::num_slots
- CircuitBuilder::add_all_lookups
- LookupGate::num_wires
- CircuitBuilder::check_gate_compatibility

**Affected Locations**
- **CircuitBuilder.check_config**: Configuration validation omits lookup-specific minimum checks for `num_routed_wires`.
- **LookupGate.num_slots**: Derives lookup slot count as `config.num_routed_wires / 2`, which can be `0`.
- **LookupTableGate.num_slots**: Derives lookup-table slot count as `config.num_routed_wires / 3`, which can be `0`.
- **CircuitBuilder.add_all_lookups**: Uses zero slot counts in `chunks_exact` and lookup-table row-count division, triggering deterministic panics.
- **LookupGate.num_wires**: A zero-slot lookup gate advertises `0` wires, so malformed lookup geometry is not rejected early.
- **CircuitBuilder.check_gate_compatibility**: Only compares `gate.num_wires()` to `config.num_wires`, allowing zero-wire malformed lookup gates through.

**Description**

Lookup support derives slot counts directly from `config.num_routed_wires`, using `/ 2` for `LookupGate` and `/ 3` for `LookupTableGate`, but no configuration-time check enforces the minimum routed-wire budget needed for either path. `CircuitBuilder::check_config` only validates FRI parameters, so undersized lookup-bearing configs are accepted even though they cannot host any lookup slots. In `CircuitBuilder::add_all_lookups`, the ordinary lookup path passes `LookupGate::num_slots(&self.config)` into `lookups.chunks_exact(num_slots)`, which panics when the derived count is `0`. The lookup-table path in the same function computes `num_lut_rows` by dividing by `LookupTableGate::num_slots(&self.config)`, which likewise panics when that count is `0`. This malformed configuration is not screened out generically because a zero-slot `LookupGate` reports `num_wires() == 0`, so `check_gate_compatibility` still accepts it.

**Root cause**

Lookup-specific minimum wire requirements are never enforced, so `LookupGate::num_slots` and `LookupTableGate::num_slots` can return `0` and `add_all_lookups` later uses those values in `chunks_exact` and division operations that require a positive slot count.

**Impact**

An attacker who can influence `CircuitConfig` can make any lookup-bearing circuit abort during construction by choosing `num_routed_wires` below the lookup minimum. This blocks circuit building and any proving workflow that depends on it, allowing reliable denial of service against services that accept untrusted circuit geometry.

</details>

<details>
<summary><b>#64717 · Medium · Missing commit-phase cap count check causes verifier panic</b></summary>

**Targets**
- fri_validate_shape::validate_fri_proof_shape
- FriProof::verify_fri_proof
- verifier::verify

**Affected Locations**
- **fri_validate_shape.validate_fri_proof_shape**: Shape validation checks each commit-phase cap height but omits the required count check against the configured number of FRI reduction rounds.
- **FriProof.verify_fri_proof**: Verification loops over every configured reduction step and directly indexes `challenges.fri_betas[i]` and `proof.commit_phase_merkle_caps[i]` without guarding the vector lengths.
- **verifier.verify**: The public verifier entrypoint validates shape, derives challenges from the supplied proof, and then reaches FRI verification on attacker-controlled input.
- **FriProof.validate_fri_proof_shape**: Only the height of each commit-phase cap is validated; no count check is performed.
- **ProofWithPublicInputs.get_challenges**: The verifier derives challenges from attacker-supplied `proof.opening_proof.commit_phase_merkle_caps`.
- **ProofWithPublicInputs.verify**: Untrusted proofs reach challenge derivation and then FRI verification through the public verifier entrypoint.
- **fri_validate_shape.validate_batch_fri_proof_shape**: Only cap heights are checked; the number of commit-phase caps is never validated.
- **FriChallenger.fri_challenges**: `fri_betas` length is derived directly from the supplied commit-phase caps.
- **fri_verifier.fri_verifier_query_round**: Verifier indexes both the beta list and commit-phase cap list once per expected reduction step.

**Description**

The two reports describe the same invariant violation around FRI commit-phase Merkle caps. `validate_fri_proof_shape` checks only that each cap has the expected height, but it never enforces that the number of supplied `commit_phase_merkle_caps` matches `params.reduction_arity_bits.len()`. Later, verification iterates once per configured reduction round and directly indexes both `challenges.fri_betas[i]` and `proof.commit_phase_merkle_caps[i]`, assuming the missing length invariant already holds. Because the `fri_betas` vector is derived from the attacker-controlled cap list, an undersized proof can pass shape validation yet still produce too few betas for the downstream loop. A malformed proof therefore reaches unchecked `Vec` indexing and panics the verifier instead of being cleanly rejected with an error.

**Root cause**

`validate_fri_proof_shape` enforces cap height but not `commit_phase_merkle_caps.len() == params.reduction_arity_bits.len()`, while downstream verification assumes that invariant and performs unchecked indexed access into both the cap list and the derived `fri_betas` list.

**Impact**

An attacker can submit a malformed proof with too few commit-phase caps and reliably abort verification by triggering an out-of-bounds panic. Any application that accepts untrusted proofs through `verify` can have proof-checking requests crashed or its verification service taken offline until the process is restarted or protected.

**Remediation**

_Explanation_

Enforce the missing structural invariant at shape validation: reject any plain or batch FRI proof unless `commit_phase_merkle_caps.len()` exactly matches `params.reduction_arity_bits.len()`, then keep the existing per-cap height checks. This fixes the root cause where challenge derivation and verifier loops assume one commit-phase cap per configured reduction round, so malformed proofs fail validation cleanly instead of reaching unchecked indexing and panicking.

---

</details>

<details>
<summary><b>#64718 · Medium · Generator deserialization lacks bounds checks for witness coordinates</b></summary>

**Targets**
- CopyGenerator::deserialize
- BaseSplitGenerator::deserialize
- ArithmeticBaseGenerator::deserialize
- ArithmeticExtensionGenerator::deserialize
- ReducingGenerator::deserialize
- PoseidonMdsGenerator::deserialize
- MulExtensionGenerator::deserialize
- PartitionWitness::try_get_target
- PartitionWitness::set_target_returning_rep
- CircuitData::from_bytes
- ProverOnlyCircuitData::from_bytes
- Buffer::read_prover_only_circuit_data
- Buffer::read_target

**Affected Locations**
- **CopyGenerator.deserialize**: Restores attacker-controlled source and destination targets with no bounds checks.
- **BaseSplitGenerator.deserialize**: Accepts unchecked `row` and `num_limbs` values that later produce out-of-range reads or writes.
- **ArithmeticBaseGenerator.deserialize**: Accepts unchecked `row` and arithmetic slot index `i` from serialized bytes.
- **ArithmeticExtensionGenerator.deserialize**: Accepts unchecked `row` and extension-operation index `i` from serialized bytes.
- **ReducingGenerator.deserialize**: Accepts an unvalidated generator row that is later converted into witness wire accesses.
- **PoseidonMdsGenerator.deserialize**: Accepts an unvalidated `row` and later uses it to build input and output wire targets.
- **MulExtensionGenerator.deserialize**: Accepts unchecked `row` and operation index `i` that later address extension-wire ranges.
- **PartitionWitness.try_get_target**: Dependency checks and witness reads index `representative_map` with derived target indexes and panic on malformed coordinates.
- **PartitionWitness.set_target_returning_rep**: Generated writes use the computed target index directly, so oversized rows or columns panic during witness merges.
- **CircuitData.from_bytes**: Public entrypoint that deserializes full circuit data, including attacker-controlled generators.
- **ProverOnlyCircuitData.from_bytes**: Public entrypoint that deserializes prover-only data and exposes malformed generator payloads directly.
- **Buffer.read_prover_only_circuit_data**: Reads the serialized generator list from bytes without enforcing generator-specific bounds invariants.
- **Buffer.read_target**: Accepts raw `Target` coordinates and virtual indices from the byte stream without validating them.
- **DefaultGeneratorSerializer.read_generator**: Tagged generator payloads are deserialized and wrapped with no structural validation.
- **DefaultGeneratorSerializer.read_target**: Raw target coordinates and virtual indices are accepted without bounds checks.
- **SimpleGeneratorAdapter.run**: Generator execution first queries dependency presence through witness lookups.
- **BaseSplitGenerator.dependencies**: Generator dependencies are built directly from the serialized `row`.
- **BaseSplitGenerator.run_once**: `run_once` writes limb wires derived from unchecked `row`/`num_limbs`, and `deserialize` performs no validation.
- **ArithmeticExtensionGenerator.dependencies**: Deserialized coordinates are converted directly into watched wire targets.
- **ArithmeticExtensionGenerator.run_once**: The same unchecked coordinates are used to read and write extension-wire ranges.
- **ArithmeticBaseGenerator.dependencies**: Generator converts unvalidated `row` and `i` into concrete wire targets for reads and writes.
- **ReducingGenerator.dependencies**: Dependencies are built directly from the serialized row.
- **ReducingGenerator.run_once**: Generator reads and writes witness targets derived from self.row.
- **ProverOnlyCircuitData.read_prover_only_circuit_data**: Serialized generators are accepted from attacker-controlled bytes.
- **generate_partial_witness.generate_partial_witness**: Witness generation executes generators and applies their generated targets.
- **PartitionWitness.target_index**: Target indexing is derived directly from row and column.
- **PoseidonMdsGenerator.dependencies**: Untrusted deserialized `row` is used to construct wire targets without validation.
- **PoseidonMdsGenerator.from_bytes**: Serialized circuit bytes are deserialized and then used directly by the proving path.
- **PoseidonMdsGenerator.read_prover_only_circuit_data**: Generators are read from attacker-controlled bytes with no structural validation of generator-specific fields.
- **PoseidonMdsGenerator.run**: Generator execution first queries whether all dependency targets are present in the witness.
- **PoseidonMdsGenerator.contains_all**: Dependency presence checks call into target lookups for every generated wire target.
- **PoseidonMdsGenerator.try_get_target**: Witness lookup indexes `representative_map` using the computed target index, panicking on an out-of-range row.
- **MulExtensionGenerator.dependencies**: Generator derives watched targets and witness accesses directly from deserialized `row`/`i`.

**Description**

Multiple generator implementations accept attacker-controlled structural fields from serialized prover artifacts without checking them against `CommonCircuitData`. This affects raw `Target` values in `CopyGenerator` and unchecked `row`, `i`, or `num_limbs` fields in `BaseSplitGenerator`, `ArithmeticBaseGenerator`, `ArithmeticExtensionGenerator`, `ReducingGenerator`, `PoseidonMdsGenerator`, and `MulExtensionGenerator`. After `CircuitData::from_bytes` or `ProverOnlyCircuitData::from_bytes` reconstructs these generators, witness generation immediately turns the deserialized fields into concrete witness locations through `dependencies()` and `run_once()`. `PartitionWitness::try_get_target` and `PartitionWitness::set_target_returning_rep` then index `representative_map` using those derived coordinates without bounds checks, so malformed artifacts panic during proving instead of failing with `IoError`. The fix is to validate each generator's decoded coordinates, indices, limb counts, and embedded targets before accepting the generator, or to add a shared post-deserialization validator that enforces those invariants for all generator types.

**Root cause**

Generator deserialization restores `Target`, `row`, `i`, and `num_limbs` fields from untrusted bytes without validating them against `CommonCircuitData`, while later witness code blindly indexes storage using the resulting coordinates.

**Impact**

A caller that can submit serialized `CircuitData` or `ProverOnlyCircuitData` can deterministically crash witness generation or `prove()` with a single malformed generator record. Replaying the same artifact can repeatedly kill prover jobs or workers, denying service to any system that accepts untrusted serialized circuits.

**Remediation**

_Explanation_

- Validate every deserialized generator against `CommonCircuitData` before `read_prover_only_circuit_data` accepts it, and return `IoError` on any out-of-bounds structural field. Check raw `Target` members (`row < degree`, `column < num_wires`, virtual-target index within the circuit’s allocated virtual-target space) and every generator-specific parameter that later derives witness locations (`row`, `i`, `num_limbs`) so that all derived wire ranges fit the gate layout and circuit dimensions before the generator is stored.

- If a shared validator is not already available, add the same bounds checks directly inside each affected `deserialize` implementation rather than hardening witness access. Reject malformed generators at deserialization time; do not rely on `PartitionWitness` panics or runtime proving checks to catch invalid coordinates.

---

</details>

<details>
<summary><b>#64719 · Medium · Unvalidated witness targets can panic the prover</b></summary>

**Targets**
- PartialWitness::set_target
- PartitionWitness::set_target_returning_rep
- CircuitData::prove
- PartitionWitness::generate_partial_witness
- Target::index

**Affected Locations**
- **PartialWitness.set_target**: Stores arbitrary caller-supplied `Target` values without validating that they belong to the circuit.
- **PartitionWitness.set_target_returning_rep**: Computes a target-derived index and immediately indexes `representative_map` without bounds checks.
- **CircuitData.prove**: Public proving entrypoint accepts caller-controlled `PartialWitness` values.
- **PartitionWitness.generate_partial_witness**: Replays all `PartialWitness` entries into `PartitionWitness` during proving.
- **Target.index**: Transforms attacker-controlled `row`, `column`, or virtual `index` fields directly into the array index used later.
- **generate_partial_witness.generate_partial_witness**: Witness generation forwards all supplied targets into PartitionWitness.
- **Target.Target**: `Target` variants expose arbitrary `row`, `column`, and `index` fields.

**Description**

Both reports describe the same failure mode: caller-controlled `Target` values are accepted into `PartialWitness` and later replayed during proving without checking that they are valid for the circuit. `CircuitData::prove` exposes a public proving entrypoint, while `PartialWitness::set_target` only handles duplicate assignments and does not reject out-of-range `Wire { row, column }` or `VirtualTarget { index }` values. When `generate_partial_witness` forwards those entries into `PartitionWitness`, `set_target_returning_rep` derives an array position from `Target::index(self.num_wires, self.degree)` and immediately uses it to index `representative_map`. Because that index is fully determined by attacker-supplied target fields and is not bounds-checked, malformed witness input causes an out-of-bounds panic instead of returning a normal `Result` error. The required fix is to validate each supplied `Target` against the circuit's valid wire and virtual-target ranges before it reaches `PartitionWitness`, or to add checked indexing there and reject invalid targets cleanly.

**Root cause**

The prover trusts `PartialWitness` entries to contain only circuit-valid `Target` values, so `set_target_returning_rep` uses `Target::index` for unchecked indexing into `representative_map` without prior bounds validation.

**Impact**

An attacker who can submit witness assignments can crash proof generation with a single malformed target. In services that generate proofs from untrusted input, this can abort requests or repeatedly kill worker threads/processes, causing a straightforward availability loss until the bad input is filtered or the service recovers.

</details>

<details>
<summary><b>#64720 · Medium · Empty polynomial coefficients cause release-mode panics</b></summary>

**Targets**
- PolynomialCoeffsExtAlgebraTarget::eval_with_powers
- PolynomialCoeffsAlgebra::eval_with_powers
- PolynomialCoeffsAlgebra::eval_base_with_powers
- PolynomialCoeffsAlgebra::new

**Affected Locations**
- **PolynomialCoeffsExtAlgebraTarget.eval_with_powers**: Uses only `debug_assert_eq!` for shape validation and then unconditionally indexes `self.0[0]`.
- **PolynomialCoeffsAlgebra.eval_with_powers**: Immediately reads `self.coeffs[0]` after a debug-only length check, so empty coefficients panic in release builds.
- **PolynomialCoeffsAlgebra.eval_base_with_powers**: Has the same unchecked `self.coeffs[0]` access pattern after a debug-only assertion.
- **PolynomialCoeffsAlgebra.new**: Accepts and stores arbitrary `coeffs` without enforcing that the polynomial is non-empty.

**Description**

Both `PolynomialCoeffsExtAlgebraTarget::eval_with_powers` and `PolynomialCoeffsAlgebra`'s fast-path evaluators assume their coefficient vectors are non-empty, but that invariant is not enforced safely in production code. In the target-backed path, the only shape check is a `debug_assert_eq!`, and the tuple struct remains publicly constructible with an empty `Vec`. In the algebra-backed path, `PolynomialCoeffsAlgebra::new` accepts an empty vector without validation, and both `eval_with_powers` and `eval_base_with_powers` immediately read `self.coeffs[0]`. As a result, malformed empty polynomials trigger out-of-bounds panics in release builds instead of being rejected cleanly. The same implementation fix addresses all of these cases: enforce a non-empty invariant at construction or add release-mode validation before indexing the first coefficient.

**Root cause**

The code relies on an implicit non-empty coefficient invariant that is not enforced in release mode before `self.0[0]` or `self.coeffs[0]` is accessed.

**Impact**

An attacker who can cause downstream code to construct one of these polynomial wrappers with an empty coefficient vector can reliably crash the evaluation path. In services that expose proof generation, verification, or circuit-building over attacker-influenced inputs, this can tear down the in-flight request and may terminate the worker or process if panics are treated as fatal.

**Remediation**

_Explanation_

Assumption: empty coefficient vectors are invalid, and the zero polynomial is represented as a single zero coefficient rather than `[]`.

- Enforce the non-empty invariant in release mode at every public construction boundary: reject empty `Vec`s in `PolynomialCoeffsAlgebra::new`, and stop relying on `debug_assert` anywhere a first coefficient is read. Replace the evaluator preconditions with release-mode checks before any `[0]` access so malformed empty polynomials fail cleanly instead of panicking.

- If you can make a small API-tightening change, make `PolynomialCoeffsExtAlgebraTarget` non-directly-constructible and require a validating constructor that rejects empty coefficients. This removes the root cause at the type boundary instead of depending on callers to preserve an implicit invariant.

---

</details>

<details>
<summary><b>#64721 · Medium · Power-table length mismatches silently truncate polynomial evaluation</b></summary>

**Targets**
- PolynomialCoeffsAlgebra::eval_with_powers
- PolynomialCoeffsAlgebra::eval_base_with_powers
- PolynomialCoeffs::eval_with_powers
- PolynomialCoeffs::eval_base_with_powers

**Affected Locations**
- **PolynomialCoeffsAlgebra.eval_with_powers**: Debug-only length checking allows truncated extension-field power tables to omit higher-degree terms in release builds.
- **PolynomialCoeffsAlgebra.eval_base_with_powers**: Debug-only length checking allows truncated base-field power tables to omit higher-degree terms in release builds.
- **PolynomialCoeffs.eval_with_powers**: The evaluator zips coefficients with caller-supplied powers after a `debug_assert_eq!`, silently returning a truncated polynomial evaluation in optimized builds.
- **PolynomialCoeffs.eval_base_with_powers**: The base-field evaluator has the same missing runtime validation and truncating `zip` behavior on malformed power slices.

**Description**

Across both `PolynomialCoeffsAlgebra` and `PolynomialCoeffs`, the power-based evaluation helpers treat `coeffs.len() == powers.len() + 1` as a debug-only invariant rather than a runtime-enforced precondition. In optimized builds, `debug_assert_eq!` is removed, yet each function still iterates with `.zip(powers)`, which stops at the shorter slice without reporting an error. If a caller supplies too few powers, all higher-degree coefficients beyond the truncated prefix are omitted and the returned value corresponds to a different, lower-degree polynomial. This affects both the extension-field and base-field variants in each type, so the same malformed-input behavior exists in four evaluators. The needed fix is the same everywhere: enforce the length relation at runtime or otherwise reject mismatched slices before performing the fold.

**Root cause**

The helpers use `debug_assert_eq!` for a required public input invariant and then evaluate with truncating `.zip(powers)`, so release builds silently ignore trailing coefficients when `powers` is too short.

**Impact**

A caller that derives `powers` from untrusted or malformed input can be induced to compute a different polynomial evaluation than intended without any failure signal. Integrations that rely on these helpers for verification or integrity checks may therefore accept invalid relations or make state decisions based on a silently weakened polynomial computation.

</details>

<details>
<summary><b>#64722 · Medium · secp256k1 field bigint constructors panic on oversized inputs</b></summary>

**Targets**
- Secp256K1Scalar::from_noncanonical_biguint
- Secp256K1Base::from_noncanonical_biguint
- Field::from_noncanonical_biguint

**Affected Locations**
- **Secp256K1Scalar.from_noncanonical_biguint**: Scalar-field constructor packs all limbs into a fixed four-word array and panics on oversized `BigUint` inputs.
- **Secp256K1Base.from_noncanonical_biguint**: Base-field constructor uses the same fixed-limb conversion pattern and panics instead of reducing arbitrary `BigUint` values.
- **Field.from_noncanonical_biguint**: The trait contract explicitly promises `n % Self::characteristic()` for arbitrary `BigUint`, making these non-reducing implementations unsafe for callers.

**Description**

Both `Secp256K1Scalar::from_noncanonical_biguint` and `Secp256K1Base::from_noncanonical_biguint` violate the documented `Field` behavior for arbitrary `BigUint` inputs. Instead of reducing `val` modulo the field characteristic, each implementation converts all `u64` limbs into a fixed `[u64; 4]` and calls `.try_into().expect(...)`. Any input larger than 256 bits therefore produces more than four limbs and triggers a panic rather than returning a valid reduced field element. The bug is exposed through a public field-construction API, so downstream code may naturally invoke it on untrusted big integers. Fixing both cases requires the same change: perform modular reduction before packing limbs, or otherwise safely handle arbitrary-length `BigUint` values without panicking.

**Root cause**

The `from_noncanonical_biguint` implementations for both secp256k1 field types assume inputs already fit in four `u64` limbs and use `.try_into().expect(...)` instead of first reducing arbitrary `BigUint` values modulo the field characteristic.

**Impact**

An attacker who can supply oversized `BigUint` values to code using these constructors can reliably trigger a panic and abort the current operation. In deployments where panics terminate the process or are not isolated, this becomes a denial-of-service condition for consumers performing secp256k1 field normalization on untrusted input.

</details>

<details>
<summary><b>#64725 · Medium · Merkle leaf commitments do not uniquely bind leaf contents</b></summary>

**Targets**
- CircuitBuilder::hash_or_noop
- CircuitBuilder::hash_n_to_m_no_pad
- merkle_proofs::verify_batch_merkle_proof_to_cap
- Hasher::hash_or_noop
- merkle_tree::fill_subtree

**Affected Locations**
- **CircuitBuilder.hash_or_noop**: Short inputs are returned directly instead of being unambiguously hashed, creating collisions between raw short leaves and actual digests.
- **CircuitBuilder.hash_n_to_m_no_pad**: Overwrite-mode sponge absorption omits padding and length commitment, allowing trailing-zero collisions for variable-length inputs.
- **merkle_proofs.verify_batch_merkle_proof_to_cap**: Proof verification recomputes leaf digests with `H::hash_or_noop`, so alternate payloads that map to the same ambiguous digest are accepted.
- **Hasher.hash_or_noop**: The CPU-side helper preserves the same no-op semantics for short inputs, propagating the ambiguous leaf encoding outside the circuit builder.
- **merkle_tree.fill_subtree**: Merkle tree construction commits arbitrary leaves with `H::hash_or_noop`, exposing the ambiguous encoding at the leaf layer.

**Description**

The leaf commitment path accepts multiple distinct payloads as the same digest because `hash_or_noop` does not enforce a unique encoding for variable-length inputs. For short inputs it returns the field elements directly, so any long leaf whose digest is `d` can be reopened as the short leaf `d.elements` with no domain separator between raw data and hashed data. For longer inputs, `hash_n_to_m_no_pad` absorbs chunks in overwrite mode without padding or an explicit length commitment, so vectors that differ only by trailing zero elements can reach the same final state. Merkle tree construction and proof verification both call `hash_or_noop` on arbitrary `Vec<F>` leaf data, which means the tree root binds only these ambiguous encodings rather than the original leaf payloads. A valid proof can therefore be reused to authenticate alternate leaves that were never uniquely committed.

**Root cause**

`hash_or_noop` and `hash_n_to_m_no_pad` reuse the same digest space for differently encoded leaf payloads without mandatory hashing, domain separation, padding, or an explicit length commitment.

**Impact**

Applications using these Merkle commitments cannot rely on a proof to identify one exact leaf value, because different payloads can produce the same accepted leaf digest. An attacker can present a valid proof for a long leaf as a different short leaf equal to its digest words, or swap between leaves that differ only by trailing zero field elements, causing verification to accept data that was not uniquely bound by the commitment.

</details>

<details>
<summary><b>#64726 · Medium · Unvalidated prover-data deserialization causes witness-generation panics</b></summary>

**Targets**
- Buffer::read_prover_only_circuit_data
- iop::generator
- PartitionWitness::set_target_returning_rep
- ProverOnlyCircuitData::from_bytes
- CircuitData::from_bytes
- PartitionWitness::new

**Affected Locations**
- **Buffer.read_prover_only_circuit_data**: Reads `generator_indices_by_watches` and `representative_map` directly from bytes without validating indices, lengths, or structural consistency.
- **iop::generator.generate_partial_witness**: Consumes the untrusted watch map and representative map during witness generation, where malformed indices trigger out-of-bounds panics.
- **PartitionWitness.set_target_returning_rep**: Indexes both `representative_map` and `values` assuming representative entries are in range.
- **ProverOnlyCircuitData.from_bytes**: Accepts raw serialized prover-only circuit bytes and forwards them into deserialization without enforcing prover-state invariants.
- **CircuitData.from_bytes**: Higher-level circuit deserialization also accepts attacker-controlled bytes that flow into prover-data parsing.
- **PartitionWitness.new**: Sizes internal `values` directly from the untrusted `representative_map` length, amplifying malformed map input into later indexing failures.
- **generate_partial_witness.generate_partial_witness**: Deserialized watcher indices are used directly to index scheduler state.

**Description**

`ProverOnlyCircuitData::from_bytes` accepts serialized prover state that includes both `generator_indices_by_watches` and `representative_map`, and the deserializer stores those structures verbatim. Later witness generation assumes both are valid internal invariants: watch lists must only contain indices within `prover_data.generators`, and every representative entry must point back into a correctly sized partition map. Because those assumptions are unchecked, tampered bytes can make `generate_partial_witness` index `generator_is_expired` out of bounds when scheduling generators, or make `PartitionWitness` index `representative_map` and `values` out of bounds on the first target assignment. In both cases the failure mode is a panic rather than an `Err`, so malformed circuit artifacts crash the proving flow before the caller can reject them cleanly. The necessary fix is to validate or reconstruct these derived prover-only structures during deserialization and reject inconsistent inputs.

**Root cause**

The deserialization path trusts serialized `generator_indices_by_watches` and `representative_map` as already-valid internal invariants instead of validating their bounds and shape or rebuilding them from trusted data.

**Impact**

An attacker who can supply or tamper with serialized circuit artifacts can make the next witness or proof generation attempt abort the worker process. This creates a reliable denial-of-service condition for proving infrastructure that loads external circuit bytes, whether the malformed data is exercised through generator scheduling or through target assignment in the partition witness.

</details>
