### PR TITLE
V12 audit: harden common/circuit-data deserialization (#71)

### DIFF
--- a/core/src/circuit_config.rs
+++ b/core/src/circuit_config.rs
@@ -232,27 +232,27 @@ pub fn check_gate_shape(
     Ok(())
 }
 
-/// Validate that the two FRI views inside `CommonCircuitData` agree.
+/// Validate that the derived `fri_params` inside `CommonCircuitData` matches `config.fri_config`.
 ///
-/// Common data stores the FRI config twice (`config.fri_config` and `fri_params.config`) and the
-/// initial FRI degree twice (`public_initial_degree_bits` and `fri_params.degree_bits`). The
-/// verifier samples query indices from `config.fri_config` and `public_initial_degree_bits` but
-/// checks proof shape and runs FRI against `fri_params`; if the copies disagree (e.g. a smaller
-/// `num_query_rounds` in `config.fri_config`), only the smaller number of query rounds is actually
-/// verified. Require the copies to match so both paths use identical parameters.
+/// `fri_params` is fully determined by `config.fri_config`, `public_initial_degree_bits`, and
+/// `config.zero_knowledge`, but the verifier draws FRI query indices from `config.fri_config`
+/// while running FRI (proof shape, reduction schedule, final polynomial, leaf salting) against
+/// `fri_params`. Any divergence in a derived field (`num_query_rounds`, `degree_bits`,
+/// `reduction_arity_bits`, `leaf_hiding`, ...) lets a forged blob weaken the FRI check instead of
+/// being rejected, so the whole structure is re-derived and compared.
 ///
-/// Comparison is used rather than recomputing `fri_params`, because recomputation on forged config
-/// (arbitrary `rate_bits` / arities) can itself panic instead of returning an error.
+/// The derivation is the fallible [`FriConfig::checked_fri_params`], which returns an error rather
+/// than panicking on forged config (arbitrary `rate_bits` / arities).
 pub fn check_fri_params_consistent(
     config: &CircuitConfig,
     public_initial_degree_bits: usize,
     fri_params: &FriParams,
 ) -> Result<(), &'static str> {
-    if fri_params.config != config.fri_config {
-        return Err("fri_params.config must match config.fri_config");
-    }
-    if fri_params.degree_bits != public_initial_degree_bits {
-        return Err("fri_params.degree_bits must match public_initial_degree_bits");
+    let expected = config
+        .fri_config
+        .checked_fri_params(public_initial_degree_bits, config.zero_knowledge)?;
+    if *fri_params != expected {
+        return Err("fri_params inconsistent with circuit config");
     }
     Ok(())
 }
@@ -312,6 +312,9 @@ pub fn check_lookup_metadata_valid(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(feature = "std"))]
+    use alloc::vec;
+
     use super::{
         check_common_data_valid, check_fri_params_consistent, check_gate_shape,
         check_lookup_metadata_valid, CircuitConfig,
@@ -420,6 +423,23 @@ mod tests {
         let config = CircuitConfig::standard_recursion_config();
         let params = config.fri_config.fri_params(10, config.zero_knowledge);
         assert!(check_fri_params_consistent(&config, 11, &params).is_err());
+    }
+
+    #[test]
+    fn check_fri_params_rejects_arity_schedule_mismatch() {
+        let config = CircuitConfig::standard_recursion_config();
+        let mut params = config.fri_config.fri_params(12, config.zero_knowledge);
+        assert!(!params.reduction_arity_bits.is_empty());
+        params.reduction_arity_bits = vec![1];
+        assert!(check_fri_params_consistent(&config, 12, &params).is_err());
+    }
+
+    #[test]
+    fn check_fri_params_rejects_leaf_hiding_mismatch() {
+        let config = CircuitConfig::standard_recursion_config();
+        let mut params = config.fri_config.fri_params(10, config.zero_knowledge);
+        params.leaf_hiding = !config.zero_knowledge;
+        assert!(check_fri_params_consistent(&config, 10, &params).is_err());
     }
 
     #[test]

--- a/core/src/circuit_config.rs
+++ b/core/src/circuit_config.rs
@@ -3,6 +3,7 @@
 use serde::Serialize;
 
 use crate::fri::{FriConfig, FriReductionStrategy};
+use crate::selectors::LookupSelectors;
 
 /// Configuration to be used when building a circuit. This defines the shape of the circuit
 /// as well as its targeted security level and sub-protocol (e.g. FRI) parameters.
@@ -109,6 +110,13 @@ impl CircuitConfig {
             return Err("num_routed_wires must be >= 3 (required for lookup gates)");
         }
 
+        // Routed wires are a subset of all wires; advice wires are the remainder. A larger
+        // routed count underflows num_advice_wires and overruns wire-opening reads during
+        // the permutation argument.
+        if self.num_routed_wires > self.num_wires {
+            return Err("num_routed_wires must not exceed num_wires");
+        }
+
         Ok(())
     }
 
@@ -123,7 +131,9 @@ impl CircuitConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::{check_common_data_valid, check_gate_shape, CircuitConfig};
+    use super::{
+        check_common_data_valid, check_gate_shape, check_lookup_metadata_valid, CircuitConfig,
+    };
 
     #[test]
     fn check_common_data_rejects_zero_quotient_degree() {
@@ -162,6 +172,50 @@ mod tests {
         assert!(check_gate_shape(config.num_wires + 1, 0, 1, &config, 1, 0, nc, 4).is_err());
         assert!(check_gate_shape(1, nc, 1, &config, 1, 0, nc, 4).is_err());
         assert!(check_gate_shape(1, 0, 5, &config, 1, 0, nc, 4).is_err());
+    }
+
+    #[test]
+    fn check_valid_rejects_routed_wires_exceeding_wires() {
+        let config = CircuitConfig {
+            num_routed_wires: 200,
+            num_wires: 143,
+            ..CircuitConfig::standard_recursion_config()
+        };
+        assert!(config.check_valid().is_err());
+    }
+
+    #[test]
+    fn check_lookup_metadata_accepts_absent_lookups() {
+        assert!(check_lookup_metadata_valid(0, 0, 0, 8, 40).is_ok());
+    }
+
+    #[test]
+    fn check_lookup_metadata_rejects_phantom_lookups() {
+        assert!(check_lookup_metadata_valid(1, 0, 0, 8, 40).is_err());
+        assert!(check_lookup_metadata_valid(0, 1, 0, 8, 40).is_err());
+    }
+
+    #[test]
+    fn check_lookup_metadata_accepts_consistent_lookups() {
+        // num_routed_wires = 80 => LookupGate slots = 40, qdf = 8 => degree 7.
+        // selectors = StartEnd(4) + 1 lut = 5; polys = ceil(40 / 7) + 1 = 7.
+        assert!(check_lookup_metadata_valid(7, 5, 1, 8, 40).is_ok());
+    }
+
+    #[test]
+    fn check_lookup_metadata_rejects_disabled_or_degenerate_polys() {
+        assert!(check_lookup_metadata_valid(0, 5, 1, 8, 40).is_err());
+        assert!(check_lookup_metadata_valid(1, 5, 1, 8, 40).is_err());
+    }
+
+    #[test]
+    fn check_lookup_metadata_rejects_wrong_selector_count() {
+        assert!(check_lookup_metadata_valid(7, 4, 1, 8, 40).is_err());
+    }
+
+    #[test]
+    fn check_lookup_metadata_rejects_low_quotient_degree() {
+        assert!(check_lookup_metadata_valid(7, 5, 1, 1, 40).is_err());
     }
 
     #[test]
@@ -300,5 +354,58 @@ pub fn check_gate_shape(
     if gate_num_constraints > num_gate_constraints {
         return Err("gate emits more constraints than num_gate_constraints");
     }
+    Ok(())
+}
+
+/// Validate lookup metadata against the declared lookup tables and circuit config.
+///
+/// `num_lookup_polys` and `num_lookup_selectors` are fully determined by the table count and
+/// config. A forged value either skips lookup constraints entirely (`num_lookup_polys == 0`
+/// makes `has_lookup` false) or mis-sizes / divides-by-zero during lookup constraint
+/// evaluation (`num_lookup_polys == 1` leaves zero accumulator chunks), so both are recomputed
+/// and compared here rather than trusted.
+///
+/// `lookup_gate_num_slots` is `LookupGate::num_slots(config)`, supplied by the caller so the
+/// per-gate wire layout stays defined in one place.
+pub fn check_lookup_metadata_valid(
+    num_lookup_polys: usize,
+    num_lookup_selectors: usize,
+    num_luts: usize,
+    quotient_degree_factor: usize,
+    lookup_gate_num_slots: usize,
+) -> Result<(), &'static str> {
+    if num_luts == 0 {
+        if num_lookup_polys != 0 {
+            return Err("num_lookup_polys must be 0 without lookup tables");
+        }
+        if num_lookup_selectors != 0 {
+            return Err("num_lookup_selectors must be 0 without lookup tables");
+        }
+        return Ok(());
+    }
+
+    // Fixed transition/init selectors, plus one end selector per lookup table.
+    let expected_selectors = (LookupSelectors::StartEnd as usize)
+        .checked_add(num_luts)
+        .ok_or("lookup selector count overflows")?;
+    if num_lookup_selectors != expected_selectors {
+        return Err("num_lookup_selectors inconsistent with lookup tables");
+    }
+
+    // Lookup accumulators chunk into degree (quotient_degree_factor - 1), so lookups require
+    // quotient_degree_factor >= 2; a smaller value divides by zero during evaluation.
+    let lookup_degree = quotient_degree_factor
+        .checked_sub(1)
+        .filter(|&d| d != 0)
+        .ok_or("quotient_degree_factor must be >= 2 with lookup tables")?;
+    // One RE polynomial on top of the Sum/LDC accumulator chunks.
+    let expected_polys = lookup_gate_num_slots
+        .div_ceil(lookup_degree)
+        .checked_add(1)
+        .ok_or("num_lookup_polys overflows")?;
+    if num_lookup_polys != expected_polys {
+        return Err("num_lookup_polys inconsistent with lookup tables");
+    }
+
     Ok(())
 }

--- a/core/src/circuit_config.rs
+++ b/core/src/circuit_config.rs
@@ -319,6 +319,7 @@ mod tests {
         check_common_data_valid, check_fri_params_consistent, check_gate_shape,
         check_lookup_metadata_valid, CircuitConfig,
     };
+    use crate::fri::{FriParams, FriReductionStrategy};
 
     #[test]
     fn check_common_data_rejects_zero_quotient_degree() {
@@ -439,6 +440,46 @@ mod tests {
         let config = CircuitConfig::standard_recursion_config();
         let mut params = config.fri_config.fri_params(10, config.zero_knowledge);
         params.leaf_hiding = !config.zero_knowledge;
+        assert!(check_fri_params_consistent(&config, 10, &params).is_err());
+    }
+
+    #[test]
+    fn check_fri_params_rejects_zero_constant_arity_strategy() {
+        let mut config = CircuitConfig::standard_recursion_config();
+        config.fri_config.reduction_strategy = FriReductionStrategy::ConstantArityBits(0, 0);
+        let params = FriParams {
+            config: config.fri_config.clone(),
+            leaf_hiding: config.zero_knowledge,
+            degree_bits: 10,
+            reduction_arity_bits: vec![],
+        };
+        assert!(check_fri_params_consistent(&config, 10, &params).is_err());
+    }
+
+    #[test]
+    fn check_fri_params_rejects_zero_fixed_arity_strategy() {
+        let mut config = CircuitConfig::standard_recursion_config();
+        config.fri_config.reduction_strategy = FriReductionStrategy::Fixed(vec![0]);
+        let params = FriParams {
+            config: config.fri_config.clone(),
+            leaf_hiding: config.zero_knowledge,
+            degree_bits: 10,
+            reduction_arity_bits: vec![0],
+        };
+        assert!(check_fri_params_consistent(&config, 10, &params).is_err());
+    }
+
+    #[test]
+    fn check_fri_params_rejects_oversized_min_size_query_count() {
+        let mut config = CircuitConfig::standard_recursion_config();
+        config.fri_config.reduction_strategy = FriReductionStrategy::MinSize(None);
+        config.fri_config.num_query_rounds = usize::MAX;
+        let params = FriParams {
+            config: config.fri_config.clone(),
+            leaf_hiding: config.zero_knowledge,
+            degree_bits: 10,
+            reduction_arity_bits: vec![],
+        };
         assert!(check_fri_params_consistent(&config, 10, &params).is_err());
     }
 

--- a/core/src/circuit_config.rs
+++ b/core/src/circuit_config.rs
@@ -139,7 +139,9 @@ mod tests {
         let qdf = 8;
         let expected = nrw.div_ceil(qdf) - 1;
         assert!(check_common_data_valid(&config, qdf, 10, 4, 4, expected, nrw, || false).is_ok());
-        assert!(check_common_data_valid(&config, qdf, 10, 4, 4, expected + 1, nrw, || false).is_err());
+        assert!(
+            check_common_data_valid(&config, qdf, 10, 4, 4, expected + 1, nrw, || false).is_err()
+        );
     }
 
     #[test]
@@ -147,7 +149,9 @@ mod tests {
         let config = CircuitConfig::standard_recursion_config();
         let nrw = config.num_routed_wires;
         let expected = nrw.div_ceil(8) - 1;
-        assert!(check_common_data_valid(&config, 8, 10, 4, 4, expected, nrw - 1, || false).is_err());
+        assert!(
+            check_common_data_valid(&config, 8, 10, 4, 4, expected, nrw - 1, || false).is_err()
+        );
     }
 
     #[test]

--- a/core/src/circuit_config.rs
+++ b/core/src/circuit_config.rs
@@ -123,7 +123,42 @@ impl CircuitConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::CircuitConfig;
+    use super::{check_common_data_valid, check_gate_shape, CircuitConfig};
+
+    #[test]
+    fn check_common_data_rejects_zero_quotient_degree() {
+        let config = CircuitConfig::standard_recursion_config();
+        let nrw = config.num_routed_wires;
+        assert!(check_common_data_valid(&config, 0, 10, 4, 4, 0, nrw, || false).is_err());
+    }
+
+    #[test]
+    fn check_common_data_validates_partial_products() {
+        let config = CircuitConfig::standard_recursion_config();
+        let nrw = config.num_routed_wires;
+        let qdf = 8;
+        let expected = nrw.div_ceil(qdf) - 1;
+        assert!(check_common_data_valid(&config, qdf, 10, 4, 4, expected, nrw, || false).is_ok());
+        assert!(check_common_data_valid(&config, qdf, 10, 4, 4, expected + 1, nrw, || false).is_err());
+    }
+
+    #[test]
+    fn check_common_data_rejects_wrong_k_is_length() {
+        let config = CircuitConfig::standard_recursion_config();
+        let nrw = config.num_routed_wires;
+        let expected = nrw.div_ceil(8) - 1;
+        assert!(check_common_data_valid(&config, 8, 10, 4, 4, expected, nrw - 1, || false).is_err());
+    }
+
+    #[test]
+    fn check_gate_shape_rejects_oversized_gates() {
+        let config = CircuitConfig::standard_recursion_config();
+        let nc = config.num_constants;
+        assert!(check_gate_shape(config.num_wires, 0, 1, &config, 1, 0, nc, 4).is_ok());
+        assert!(check_gate_shape(config.num_wires + 1, 0, 1, &config, 1, 0, nc, 4).is_err());
+        assert!(check_gate_shape(1, nc, 1, &config, 1, 0, nc, 4).is_err());
+        assert!(check_gate_shape(1, 0, 5, &config, 1, 0, nc, 4).is_err());
+    }
 
     #[test]
     fn standard_helpers_select_expected_zk_modes() {
@@ -172,6 +207,8 @@ mod tests {
 /// * `rate_bits` - FRI rate bits from config
 /// * `public_initial_degree_bits` - Public initial FRI degree bits
 /// * `trace_degree_bits` - Trace polynomial degree bits
+/// * `num_partial_products` - Declared number of partial products
+/// * `k_is_len` - Length of the permutation-argument coset shift vector
 /// * `luts` - Lookup tables (as slice of slices for flexibility)
 ///
 /// # Returns
@@ -182,14 +219,37 @@ pub fn check_common_data_valid(
     rate_bits: usize,
     public_initial_degree_bits: usize,
     trace_degree_bits: usize,
+    num_partial_products: usize,
+    k_is_len: usize,
     luts_empty_check: impl Fn() -> bool,
 ) -> Result<(), &'static str> {
     config.check_valid()?;
+
+    // The permutation argument indexes one coset shift per routed wire.
+    if k_is_len != config.num_routed_wires {
+        return Err("k_is length must equal num_routed_wires");
+    }
+
+    // A zero quotient degree factor breaks partial-product chunking and quotient sizing.
+    if quotient_degree_factor == 0 {
+        return Err("quotient_degree_factor must not be 0");
+    }
 
     // Quotient degree must fit within FRI rate.
     let quotient_degree_bits = crate::util::log2_ceil(quotient_degree_factor);
     if quotient_degree_bits > rate_bits {
         return Err("quotient_degree_factor exceeds FRI rate_bits");
+    }
+
+    // num_partial_products is fully determined by the routed-wire count and quotient degree;
+    // an inconsistent value mis-sizes the partial-product portion of every proof.
+    let expected_partial_products = config
+        .num_routed_wires
+        .div_ceil(quotient_degree_factor)
+        .checked_sub(1)
+        .ok_or("num_partial_products underflows")?;
+    if num_partial_products != expected_partial_products {
+        return Err("num_partial_products inconsistent with circuit config");
     }
 
     // Public initial degree must be at least as large as trace degree.
@@ -202,5 +262,39 @@ pub fn check_common_data_valid(
         return Err("lookup table is empty");
     }
 
+    Ok(())
+}
+
+/// Validate a single gate's declared shape against the surrounding circuit data.
+///
+/// Intended for deserialization of untrusted data: ensures a gate cannot reference more
+/// wires, constants, or constraints than the circuit configuration accounts for, which
+/// would otherwise cause out-of-bounds access during constraint evaluation.
+///
+/// `num_selectors` and `num_lookup_selectors` are the constant slots consumed before a
+/// gate's own constants, so a gate's constants must fit in what remains.
+pub fn check_gate_shape(
+    gate_num_wires: usize,
+    gate_num_constants: usize,
+    gate_num_constraints: usize,
+    config: &CircuitConfig,
+    num_selectors: usize,
+    num_lookup_selectors: usize,
+    num_constants: usize,
+    num_gate_constraints: usize,
+) -> Result<(), &'static str> {
+    if gate_num_wires > config.num_wires {
+        return Err("gate uses more wires than the circuit configuration provides");
+    }
+    let constants_used = num_selectors
+        .checked_add(num_lookup_selectors)
+        .and_then(|prefix| prefix.checked_add(gate_num_constants))
+        .ok_or("gate constant count overflows")?;
+    if constants_used > num_constants {
+        return Err("gate uses more constants than the circuit configuration provides");
+    }
+    if gate_num_constraints > num_gate_constraints {
+        return Err("gate emits more constraints than num_gate_constraints");
+    }
     Ok(())
 }

--- a/core/src/circuit_config.rs
+++ b/core/src/circuit_config.rs
@@ -2,7 +2,7 @@
 
 use serde::Serialize;
 
-use crate::fri::{FriConfig, FriReductionStrategy};
+use crate::fri::{FriConfig, FriParams, FriReductionStrategy};
 use crate::selectors::LookupSelectors;
 
 /// Configuration to be used when building a circuit. This defines the shape of the circuit
@@ -129,131 +129,6 @@ impl CircuitConfig {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{
-        check_common_data_valid, check_gate_shape, check_lookup_metadata_valid, CircuitConfig,
-    };
-
-    #[test]
-    fn check_common_data_rejects_zero_quotient_degree() {
-        let config = CircuitConfig::standard_recursion_config();
-        let nrw = config.num_routed_wires;
-        assert!(check_common_data_valid(&config, 0, 10, 4, 4, 0, nrw, || false).is_err());
-    }
-
-    #[test]
-    fn check_common_data_validates_partial_products() {
-        let config = CircuitConfig::standard_recursion_config();
-        let nrw = config.num_routed_wires;
-        let qdf = 8;
-        let expected = nrw.div_ceil(qdf) - 1;
-        assert!(check_common_data_valid(&config, qdf, 10, 4, 4, expected, nrw, || false).is_ok());
-        assert!(
-            check_common_data_valid(&config, qdf, 10, 4, 4, expected + 1, nrw, || false).is_err()
-        );
-    }
-
-    #[test]
-    fn check_common_data_rejects_wrong_k_is_length() {
-        let config = CircuitConfig::standard_recursion_config();
-        let nrw = config.num_routed_wires;
-        let expected = nrw.div_ceil(8) - 1;
-        assert!(
-            check_common_data_valid(&config, 8, 10, 4, 4, expected, nrw - 1, || false).is_err()
-        );
-    }
-
-    #[test]
-    fn check_gate_shape_rejects_oversized_gates() {
-        let config = CircuitConfig::standard_recursion_config();
-        let nc = config.num_constants;
-        assert!(check_gate_shape(config.num_wires, 0, 1, &config, 1, 0, nc, 4).is_ok());
-        assert!(check_gate_shape(config.num_wires + 1, 0, 1, &config, 1, 0, nc, 4).is_err());
-        assert!(check_gate_shape(1, nc, 1, &config, 1, 0, nc, 4).is_err());
-        assert!(check_gate_shape(1, 0, 5, &config, 1, 0, nc, 4).is_err());
-    }
-
-    #[test]
-    fn check_valid_rejects_routed_wires_exceeding_wires() {
-        let config = CircuitConfig {
-            num_routed_wires: 200,
-            num_wires: 143,
-            ..CircuitConfig::standard_recursion_config()
-        };
-        assert!(config.check_valid().is_err());
-    }
-
-    #[test]
-    fn check_lookup_metadata_accepts_absent_lookups() {
-        assert!(check_lookup_metadata_valid(0, 0, 0, 8, 40).is_ok());
-    }
-
-    #[test]
-    fn check_lookup_metadata_rejects_phantom_lookups() {
-        assert!(check_lookup_metadata_valid(1, 0, 0, 8, 40).is_err());
-        assert!(check_lookup_metadata_valid(0, 1, 0, 8, 40).is_err());
-    }
-
-    #[test]
-    fn check_lookup_metadata_accepts_consistent_lookups() {
-        // num_routed_wires = 80 => LookupGate slots = 40, qdf = 8 => degree 7.
-        // selectors = StartEnd(4) + 1 lut = 5; polys = ceil(40 / 7) + 1 = 7.
-        assert!(check_lookup_metadata_valid(7, 5, 1, 8, 40).is_ok());
-    }
-
-    #[test]
-    fn check_lookup_metadata_rejects_disabled_or_degenerate_polys() {
-        assert!(check_lookup_metadata_valid(0, 5, 1, 8, 40).is_err());
-        assert!(check_lookup_metadata_valid(1, 5, 1, 8, 40).is_err());
-    }
-
-    #[test]
-    fn check_lookup_metadata_rejects_wrong_selector_count() {
-        assert!(check_lookup_metadata_valid(7, 4, 1, 8, 40).is_err());
-    }
-
-    #[test]
-    fn check_lookup_metadata_rejects_low_quotient_degree() {
-        assert!(check_lookup_metadata_valid(7, 5, 1, 1, 40).is_err());
-    }
-
-    #[test]
-    fn standard_helpers_select_expected_zk_modes() {
-        let disabled = CircuitConfig::standard_recursion_config();
-        assert!(!disabled.zero_knowledge);
-
-        let zk = CircuitConfig::standard_recursion_zk_config();
-        assert!(zk.zero_knowledge);
-    }
-
-    #[test]
-    fn circuit_config_validate_accepts_valid_num_challenges() {
-        let config = CircuitConfig::standard_recursion_config();
-        config.validate(); // Should not panic (num_challenges = 2)
-    }
-
-    #[test]
-    #[should_panic(expected = "num_challenges must not be 0")]
-    fn circuit_config_validate_rejects_zero_num_challenges() {
-        let config = CircuitConfig {
-            num_challenges: 0, // Invalid - voids soundness
-            ..CircuitConfig::standard_recursion_config()
-        };
-        config.validate();
-    }
-
-    #[test]
-    #[should_panic(expected = "num_constants must not be 0")]
-    fn circuit_config_validate_rejects_zero_num_constants() {
-        let config = CircuitConfig {
-            num_constants: 0, // Invalid - causes infinite loop
-            ..CircuitConfig::standard_recursion_config()
-        };
-        config.validate();
-    }
-}
-
 /// Validate common circuit data fields shared between prover and verifier.
 ///
 /// This is a free function to avoid duplication between `CommonCircuitData::check_valid`
@@ -357,6 +232,31 @@ pub fn check_gate_shape(
     Ok(())
 }
 
+/// Validate that the two FRI views inside `CommonCircuitData` agree.
+///
+/// Common data stores the FRI config twice (`config.fri_config` and `fri_params.config`) and the
+/// initial FRI degree twice (`public_initial_degree_bits` and `fri_params.degree_bits`). The
+/// verifier samples query indices from `config.fri_config` and `public_initial_degree_bits` but
+/// checks proof shape and runs FRI against `fri_params`; if the copies disagree (e.g. a smaller
+/// `num_query_rounds` in `config.fri_config`), only the smaller number of query rounds is actually
+/// verified. Require the copies to match so both paths use identical parameters.
+///
+/// Comparison is used rather than recomputing `fri_params`, because recomputation on forged config
+/// (arbitrary `rate_bits` / arities) can itself panic instead of returning an error.
+pub fn check_fri_params_consistent(
+    config: &CircuitConfig,
+    public_initial_degree_bits: usize,
+    fri_params: &FriParams,
+) -> Result<(), &'static str> {
+    if fri_params.config != config.fri_config {
+        return Err("fri_params.config must match config.fri_config");
+    }
+    if fri_params.degree_bits != public_initial_degree_bits {
+        return Err("fri_params.degree_bits must match public_initial_degree_bits");
+    }
+    Ok(())
+}
+
 /// Validate lookup metadata against the declared lookup tables and circuit config.
 ///
 /// `num_lookup_polys` and `num_lookup_selectors` are fully determined by the table count and
@@ -408,4 +308,152 @@ pub fn check_lookup_metadata_valid(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        check_common_data_valid, check_fri_params_consistent, check_gate_shape,
+        check_lookup_metadata_valid, CircuitConfig,
+    };
+
+    #[test]
+    fn check_common_data_rejects_zero_quotient_degree() {
+        let config = CircuitConfig::standard_recursion_config();
+        let nrw = config.num_routed_wires;
+        assert!(check_common_data_valid(&config, 0, 10, 4, 4, 0, nrw, || false).is_err());
+    }
+
+    #[test]
+    fn check_common_data_validates_partial_products() {
+        let config = CircuitConfig::standard_recursion_config();
+        let nrw = config.num_routed_wires;
+        let qdf = 8;
+        let expected = nrw.div_ceil(qdf) - 1;
+        assert!(check_common_data_valid(&config, qdf, 10, 4, 4, expected, nrw, || false).is_ok());
+        assert!(
+            check_common_data_valid(&config, qdf, 10, 4, 4, expected + 1, nrw, || false).is_err()
+        );
+    }
+
+    #[test]
+    fn check_common_data_rejects_wrong_k_is_length() {
+        let config = CircuitConfig::standard_recursion_config();
+        let nrw = config.num_routed_wires;
+        let expected = nrw.div_ceil(8) - 1;
+        assert!(
+            check_common_data_valid(&config, 8, 10, 4, 4, expected, nrw - 1, || false).is_err()
+        );
+    }
+
+    #[test]
+    fn check_gate_shape_rejects_oversized_gates() {
+        let config = CircuitConfig::standard_recursion_config();
+        let nc = config.num_constants;
+        assert!(check_gate_shape(config.num_wires, 0, 1, &config, 1, 0, nc, 4).is_ok());
+        assert!(check_gate_shape(config.num_wires + 1, 0, 1, &config, 1, 0, nc, 4).is_err());
+        assert!(check_gate_shape(1, nc, 1, &config, 1, 0, nc, 4).is_err());
+        assert!(check_gate_shape(1, 0, 5, &config, 1, 0, nc, 4).is_err());
+    }
+
+    #[test]
+    fn check_valid_rejects_routed_wires_exceeding_wires() {
+        let config = CircuitConfig {
+            num_routed_wires: 200,
+            num_wires: 143,
+            ..CircuitConfig::standard_recursion_config()
+        };
+        assert!(config.check_valid().is_err());
+    }
+
+    #[test]
+    fn check_lookup_metadata_accepts_absent_lookups() {
+        assert!(check_lookup_metadata_valid(0, 0, 0, 8, 40).is_ok());
+    }
+
+    #[test]
+    fn check_lookup_metadata_rejects_phantom_lookups() {
+        assert!(check_lookup_metadata_valid(1, 0, 0, 8, 40).is_err());
+        assert!(check_lookup_metadata_valid(0, 1, 0, 8, 40).is_err());
+    }
+
+    #[test]
+    fn check_lookup_metadata_accepts_consistent_lookups() {
+        // num_routed_wires = 80 => LookupGate slots = 40, qdf = 8 => degree 7.
+        // selectors = StartEnd(4) + 1 lut = 5; polys = ceil(40 / 7) + 1 = 7.
+        assert!(check_lookup_metadata_valid(7, 5, 1, 8, 40).is_ok());
+    }
+
+    #[test]
+    fn check_lookup_metadata_rejects_disabled_or_degenerate_polys() {
+        assert!(check_lookup_metadata_valid(0, 5, 1, 8, 40).is_err());
+        assert!(check_lookup_metadata_valid(1, 5, 1, 8, 40).is_err());
+    }
+
+    #[test]
+    fn check_lookup_metadata_rejects_wrong_selector_count() {
+        assert!(check_lookup_metadata_valid(7, 4, 1, 8, 40).is_err());
+    }
+
+    #[test]
+    fn check_lookup_metadata_rejects_low_quotient_degree() {
+        assert!(check_lookup_metadata_valid(7, 5, 1, 1, 40).is_err());
+    }
+
+    #[test]
+    fn check_fri_params_accepts_derived_params() {
+        let config = CircuitConfig::standard_recursion_config();
+        let params = config.fri_config.fri_params(10, config.zero_knowledge);
+        assert!(check_fri_params_consistent(&config, 10, &params).is_ok());
+    }
+
+    #[test]
+    fn check_fri_params_rejects_query_round_mismatch() {
+        let config = CircuitConfig::standard_recursion_config();
+        let mut params = config.fri_config.fri_params(10, config.zero_knowledge);
+        params.config.num_query_rounds -= 1;
+        assert!(check_fri_params_consistent(&config, 10, &params).is_err());
+    }
+
+    #[test]
+    fn check_fri_params_rejects_degree_bits_mismatch() {
+        let config = CircuitConfig::standard_recursion_config();
+        let params = config.fri_config.fri_params(10, config.zero_knowledge);
+        assert!(check_fri_params_consistent(&config, 11, &params).is_err());
+    }
+
+    #[test]
+    fn standard_helpers_select_expected_zk_modes() {
+        let disabled = CircuitConfig::standard_recursion_config();
+        assert!(!disabled.zero_knowledge);
+
+        let zk = CircuitConfig::standard_recursion_zk_config();
+        assert!(zk.zero_knowledge);
+    }
+
+    #[test]
+    fn circuit_config_validate_accepts_valid_num_challenges() {
+        let config = CircuitConfig::standard_recursion_config();
+        config.validate(); // Should not panic (num_challenges = 2)
+    }
+
+    #[test]
+    #[should_panic(expected = "num_challenges must not be 0")]
+    fn circuit_config_validate_rejects_zero_num_challenges() {
+        let config = CircuitConfig {
+            num_challenges: 0, // Invalid - voids soundness
+            ..CircuitConfig::standard_recursion_config()
+        };
+        config.validate();
+    }
+
+    #[test]
+    #[should_panic(expected = "num_constants must not be 0")]
+    fn circuit_config_validate_rejects_zero_num_constants() {
+        let config = CircuitConfig {
+            num_constants: 0, // Invalid - causes infinite loop
+            ..CircuitConfig::standard_recursion_config()
+        };
+        config.validate();
+    }
 }

--- a/core/src/fri.rs
+++ b/core/src/fri.rs
@@ -230,6 +230,17 @@ impl FriConfig {
     pub const fn num_cap_elements(&self) -> usize {
         1 << self.cap_height
     }
+
+    /// Validate invariants that hold for any genuinely-built circuit.
+    ///
+    /// Intended for deserialization of untrusted data: a config that fails these checks
+    /// would let verification skip all queries (zero soundness), so it is rejected.
+    pub fn check_valid(&self) -> Result<(), &'static str> {
+        if self.num_query_rounds == 0 {
+            return Err("num_query_rounds must not be 0 (zero queries means no soundness)");
+        }
+        Ok(())
+    }
 }
 
 /// FRI parameters, including generated parameters which are specific to an instance size, in
@@ -275,6 +286,27 @@ impl FriParams {
 
     pub fn final_poly_len(&self) -> usize {
         1 << self.final_poly_bits()
+    }
+
+    /// Validate invariants that hold for any genuinely-built circuit.
+    ///
+    /// Intended for deserialization of untrusted data: rejects reduction schedules that
+    /// would otherwise underflow [`Self::final_poly_bits`] or drive oversized FRI loops.
+    pub fn check_valid(&self) -> Result<(), &'static str> {
+        self.config.check_valid()?;
+        let mut total_arities = 0usize;
+        for &arity_bits in &self.reduction_arity_bits {
+            if arity_bits > self.degree_bits {
+                return Err("FRI reduction arity exceeds degree_bits");
+            }
+            total_arities = total_arities
+                .checked_add(arity_bits)
+                .ok_or("FRI reduction arities sum overflows")?;
+        }
+        if total_arities > self.degree_bits {
+            return Err("sum of FRI reduction arities exceeds degree_bits");
+        }
+        Ok(())
     }
 }
 

--- a/core/src/fri.rs
+++ b/core/src/fri.rs
@@ -38,30 +38,62 @@ pub enum FriReductionStrategy {
 
 impl FriReductionStrategy {
     /// The arity of each FRI reduction step, expressed as the log2 of the actual arity.
+    ///
+    /// Panics on parameters that cannot describe a real circuit; use
+    /// [`Self::checked_reduction_arity_bits`] when deriving from untrusted data.
     pub fn reduction_arity_bits(
+        &self,
+        degree_bits: usize,
+        rate_bits: usize,
+        cap_height: usize,
+        num_queries: usize,
+    ) -> Vec<usize> {
+        self.checked_reduction_arity_bits(degree_bits, rate_bits, cap_height, num_queries)
+            .expect("invalid FRI reduction parameters")
+    }
+
+    /// Fallible [`Self::reduction_arity_bits`] for deserialization of untrusted data: returns an
+    /// error instead of panicking (overflow/underflow) on forged FRI parameters.
+    pub fn checked_reduction_arity_bits(
         &self,
         mut degree_bits: usize,
         rate_bits: usize,
         cap_height: usize,
         num_queries: usize,
-    ) -> Vec<usize> {
+    ) -> Result<Vec<usize>, &'static str> {
+        // The LDE layer is 2^(degree_bits + rate_bits); bound it so the derivations below cannot
+        // overflow and the MinSize search stays finite.
+        degree_bits
+            .checked_add(rate_bits)
+            .filter(|&b| b < usize::BITS as usize)
+            .ok_or("FRI degree_bits + rate_bits exceeds usize width")?;
         match self {
-            FriReductionStrategy::Fixed(reduction_arity_bits) => reduction_arity_bits.to_vec(),
+            FriReductionStrategy::Fixed(reduction_arity_bits) => Ok(reduction_arity_bits.to_vec()),
             &FriReductionStrategy::ConstantArityBits(arity_bits, final_poly_bits) => {
                 let mut result = Vec::new();
-                while degree_bits > final_poly_bits
-                    && degree_bits + rate_bits - arity_bits >= cap_height
-                {
+                while degree_bits > final_poly_bits {
+                    let layer_bits = degree_bits
+                        .checked_add(rate_bits)
+                        .and_then(|v| v.checked_sub(arity_bits))
+                        .ok_or("FRI reduction arity exceeds the LDE layer size")?;
+                    if layer_bits < cap_height {
+                        break;
+                    }
+                    if degree_bits < arity_bits {
+                        return Err("FRI reduction arity exceeds degree_bits");
+                    }
                     result.push(arity_bits);
-                    assert!(degree_bits >= arity_bits);
                     degree_bits -= arity_bits;
                 }
                 result.shrink_to_fit();
-                result
+                Ok(result)
             }
-            FriReductionStrategy::MinSize(opt_max_arity_bits) => {
-                min_size_arity_bits(degree_bits, rate_bits, num_queries, *opt_max_arity_bits)
-            }
+            FriReductionStrategy::MinSize(opt_max_arity_bits) => Ok(min_size_arity_bits(
+                degree_bits,
+                rate_bits,
+                num_queries,
+                *opt_max_arity_bits,
+            )),
         }
     }
 
@@ -213,18 +245,29 @@ impl FriConfig {
     }
 
     pub fn fri_params(&self, degree_bits: usize, leaf_hiding: bool) -> FriParams {
-        let reduction_arity_bits = self.reduction_strategy.reduction_arity_bits(
+        self.checked_fri_params(degree_bits, leaf_hiding)
+            .expect("invalid FRI parameters")
+    }
+
+    /// Fallible [`Self::fri_params`] for deserialization of untrusted data: derives the full
+    /// [`FriParams`] (including `reduction_arity_bits`) without panicking on forged config.
+    pub fn checked_fri_params(
+        &self,
+        degree_bits: usize,
+        leaf_hiding: bool,
+    ) -> Result<FriParams, &'static str> {
+        let reduction_arity_bits = self.reduction_strategy.checked_reduction_arity_bits(
             degree_bits,
             self.rate_bits,
             self.cap_height,
             self.num_query_rounds,
-        );
-        FriParams {
+        )?;
+        Ok(FriParams {
             config: self.clone(),
             leaf_hiding,
             degree_bits,
             reduction_arity_bits,
-        }
+        })
     }
 
     pub const fn num_cap_elements(&self) -> usize {

--- a/core/src/fri.rs
+++ b/core/src/fri.rs
@@ -68,8 +68,14 @@ impl FriReductionStrategy {
             .filter(|&b| b < usize::BITS as usize)
             .ok_or("FRI degree_bits + rate_bits exceeds usize width")?;
         match self {
-            FriReductionStrategy::Fixed(reduction_arity_bits) => Ok(reduction_arity_bits.to_vec()),
+            FriReductionStrategy::Fixed(reduction_arity_bits) => {
+                check_reduction_arity_bits(reduction_arity_bits, degree_bits)?;
+                Ok(reduction_arity_bits.to_vec())
+            }
             &FriReductionStrategy::ConstantArityBits(arity_bits, final_poly_bits) => {
+                if arity_bits == 0 {
+                    return Err("FRI reduction arity must not be 0");
+                }
                 let mut result = Vec::new();
                 while degree_bits > final_poly_bits {
                     let layer_bits = degree_bits
@@ -88,12 +94,12 @@ impl FriReductionStrategy {
                 result.shrink_to_fit();
                 Ok(result)
             }
-            FriReductionStrategy::MinSize(opt_max_arity_bits) => Ok(min_size_arity_bits(
+            FriReductionStrategy::MinSize(opt_max_arity_bits) => checked_min_size_arity_bits(
                 degree_bits,
                 rate_bits,
                 num_queries,
                 *opt_max_arity_bits,
-            )),
+            ),
         }
     }
 
@@ -121,18 +127,45 @@ impl FriReductionStrategy {
     }
 }
 
-fn min_size_arity_bits(
+fn check_reduction_arity_bits(
+    arity_bits: &[usize],
+    degree_bits: usize,
+) -> Result<(), &'static str> {
+    let mut total_arities = 0usize;
+    for &arity_bits in arity_bits {
+        if arity_bits == 0 {
+            return Err("FRI reduction arity must not be 0");
+        }
+        if arity_bits > degree_bits {
+            return Err("FRI reduction arity exceeds degree_bits");
+        }
+        total_arities = total_arities
+            .checked_add(arity_bits)
+            .ok_or("FRI reduction arities sum overflows")?;
+    }
+    if total_arities > degree_bits {
+        return Err("sum of FRI reduction arities exceeds degree_bits");
+    }
+    Ok(())
+}
+
+fn checked_min_size_arity_bits(
     degree_bits: usize,
     rate_bits: usize,
     num_queries: usize,
     opt_max_arity_bits: Option<usize>,
-) -> Vec<usize> {
+) -> Result<Vec<usize>, &'static str> {
     // 2^4 is the largest arity we see in optimal reduction sequences in practice. For 2^5 to occur
     // in an optimal sequence, we would need a really massive polynomial.
     let max_arity_bits = opt_max_arity_bits.unwrap_or(4);
 
-    let (mut arity_bits, fri_proof_size) =
-        min_size_arity_bits_helper(degree_bits, rate_bits, num_queries, max_arity_bits, vec![]);
+    let (mut arity_bits, fri_proof_size) = checked_min_size_arity_bits_helper(
+        degree_bits,
+        rate_bits,
+        num_queries,
+        max_arity_bits,
+        vec![],
+    )?;
     arity_bits.shrink_to_fit();
 
     debug!(
@@ -140,23 +173,31 @@ fn min_size_arity_bits(
         arity_bits, fri_proof_size
     );
 
-    arity_bits
+    Ok(arity_bits)
 }
 
 /// Return `(arity_bits, fri_proof_size)`.
-fn min_size_arity_bits_helper(
+fn checked_min_size_arity_bits_helper(
     degree_bits: usize,
     rate_bits: usize,
     num_queries: usize,
     global_max_arity_bits: usize,
     prefix: Vec<usize>,
-) -> (Vec<usize>, usize) {
-    let sum_of_arities: usize = prefix.iter().sum();
-    let current_layer_bits = degree_bits + rate_bits - sum_of_arities;
-    assert!(current_layer_bits >= rate_bits);
+) -> Result<(Vec<usize>, usize), &'static str> {
+    let sum_of_arities = prefix.iter().try_fold(0usize, |acc, &arity_bits| {
+        acc.checked_add(arity_bits)
+            .ok_or("FRI reduction arities sum overflows")
+    })?;
+    let current_layer_bits = degree_bits
+        .checked_add(rate_bits)
+        .and_then(|bits| bits.checked_sub(sum_of_arities))
+        .ok_or("FRI reduction arities exceed the LDE layer size")?;
+    if current_layer_bits < rate_bits {
+        return Err("sum of FRI reduction arities exceeds degree_bits");
+    }
 
     let mut best_arity_bits = prefix.clone();
-    let mut best_size = relative_proof_size(degree_bits, rate_bits, num_queries, &prefix);
+    let mut best_size = checked_relative_proof_size(degree_bits, rate_bits, num_queries, &prefix)?;
 
     // The largest next_arity_bits to search. Note that any optimal arity sequence will be
     // monotonically non-increasing, as a larger arity will shrink more Merkle proofs if it occurs
@@ -171,53 +212,84 @@ fn min_size_arity_bits_helper(
         let mut extended_prefix = prefix.clone();
         extended_prefix.push(next_arity_bits);
 
-        let (arity_bits, size) = min_size_arity_bits_helper(
+        let (arity_bits, size) = checked_min_size_arity_bits_helper(
             degree_bits,
             rate_bits,
             num_queries,
             max_arity_bits,
             extended_prefix,
-        );
+        )?;
         if size < best_size {
             best_arity_bits = arity_bits;
             best_size = size;
         }
     }
 
-    (best_arity_bits, best_size)
+    Ok((best_arity_bits, best_size))
 }
 
 /// Compute the approximate size of a FRI proof with the given reduction arities. Note that this
 /// ignores initial evaluations, which aren't affected by arities, and some other minor
 /// contributions. The result is measured in field elements.
-fn relative_proof_size(
+fn checked_relative_proof_size(
     degree_bits: usize,
     rate_bits: usize,
     num_queries: usize,
     arity_bits: &[usize],
-) -> usize {
+) -> Result<usize, &'static str> {
     const D: usize = 4;
 
-    let mut current_layer_bits = degree_bits + rate_bits;
+    let mut current_layer_bits = degree_bits
+        .checked_add(rate_bits)
+        .ok_or("FRI degree_bits + rate_bits exceeds usize width")?;
 
-    let mut total_elems = 0;
-    for arity_bits in arity_bits {
-        let arity = 1 << arity_bits;
+    let mut total_elems = 0usize;
+    for &arity_bits in arity_bits {
+        if arity_bits == 0 {
+            return Err("FRI reduction arity must not be 0");
+        }
+        let arity = 1usize
+            .checked_shl(arity_bits as u32)
+            .ok_or("FRI reduction arity exceeds usize width")?;
 
         // Add neighboring evaluations, which are extension field elements.
-        total_elems += (arity - 1) * D * num_queries;
+        let neighboring_elems = arity
+            .checked_sub(1)
+            .and_then(|n| n.checked_mul(D))
+            .and_then(|n| n.checked_mul(num_queries))
+            .ok_or("FRI proof size estimate overflows")?;
+        total_elems = total_elems
+            .checked_add(neighboring_elems)
+            .ok_or("FRI proof size estimate overflows")?;
         // Add siblings in the Merkle path.
-        total_elems += current_layer_bits * 4 * num_queries;
+        let sibling_elems = current_layer_bits
+            .checked_mul(4)
+            .and_then(|n| n.checked_mul(num_queries))
+            .ok_or("FRI proof size estimate overflows")?;
+        total_elems = total_elems
+            .checked_add(sibling_elems)
+            .ok_or("FRI proof size estimate overflows")?;
 
-        current_layer_bits -= arity_bits;
+        current_layer_bits = current_layer_bits
+            .checked_sub(arity_bits)
+            .ok_or("FRI reduction arities exceed the LDE layer size")?;
     }
 
     // Add the final polynomial's coefficients.
-    assert!(current_layer_bits >= rate_bits);
-    let final_poly_len = 1 << (current_layer_bits - rate_bits);
-    total_elems += D * final_poly_len;
+    let final_poly_bits = current_layer_bits
+        .checked_sub(rate_bits)
+        .ok_or("sum of FRI reduction arities exceeds degree_bits")?;
+    let final_poly_len = 1usize
+        .checked_shl(final_poly_bits as u32)
+        .ok_or("FRI final polynomial length exceeds usize width")?;
+    let final_poly_elems = D
+        .checked_mul(final_poly_len)
+        .ok_or("FRI proof size estimate overflows")?;
+    total_elems = total_elems
+        .checked_add(final_poly_elems)
+        .ok_or("FRI proof size estimate overflows")?;
 
-    total_elems
+    Ok(total_elems)
 }
 
 /// A configuration for the FRI protocol.
@@ -339,6 +411,9 @@ impl FriParams {
         self.config.check_valid()?;
         let mut total_arities = 0usize;
         for &arity_bits in &self.reduction_arity_bits {
+            if arity_bits == 0 {
+                return Err("FRI reduction arity must not be 0");
+            }
             if arity_bits > self.degree_bits {
                 return Err("FRI reduction arity exceeds degree_bits");
             }

--- a/core/src/selectors.rs
+++ b/core/src/selectors.rs
@@ -33,14 +33,19 @@ impl SelectorsInfo {
         if self.selector_indices.len() != num_gates {
             return Err("selector_indices length does not match the number of gates");
         }
-        for &index in &self.selector_indices {
-            if index >= self.groups.len() {
-                return Err("selector index out of range");
-            }
-        }
         for group in &self.groups {
             if group.start > group.end || group.end > num_gates {
                 return Err("selector group range out of bounds");
+            }
+        }
+        // A gate's selector index must point at the group that actually contains it: the
+        // filter for gate `i` is built from `groups[selector_indices[i]]` with `i` as the
+        // active row, and a group that excludes `i` mis-evaluates that filter (skipping the
+        // gate's constraints). `compute_filter` relies on this via a release-stripped assert.
+        for (gate_idx, &index) in self.selector_indices.iter().enumerate() {
+            let group = self.groups.get(index).ok_or("selector index out of range")?;
+            if !group.contains(&gate_idx) {
+                return Err("selector group does not contain its gate");
             }
         }
         let prefix = self
@@ -67,4 +72,40 @@ pub enum LookupSelectors {
     InitSre,
     LastLdc,
     StartEnd,
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(not(feature = "std"))]
+    use alloc::vec;
+
+    use super::SelectorsInfo;
+
+    #[test]
+    fn check_valid_accepts_containing_groups() {
+        let info = SelectorsInfo {
+            selector_indices: vec![0, 0, 1],
+            groups: vec![0..2, 2..3],
+        };
+        assert!(info.check_valid(3, 0, 8).is_ok());
+    }
+
+    #[test]
+    fn check_valid_rejects_group_not_containing_its_gate() {
+        // Gate 2 is reassigned to group 0 (0..2), which does not contain index 2.
+        let info = SelectorsInfo {
+            selector_indices: vec![0, 0, 0],
+            groups: vec![0..2, 2..3],
+        };
+        assert!(info.check_valid(3, 0, 8).is_err());
+    }
+
+    #[test]
+    fn check_valid_rejects_out_of_range_index() {
+        let info = SelectorsInfo {
+            selector_indices: vec![0, 5],
+            groups: vec![0..2],
+        };
+        assert!(info.check_valid(2, 0, 8).is_err());
+    }
 }

--- a/core/src/selectors.rs
+++ b/core/src/selectors.rs
@@ -43,7 +43,10 @@ impl SelectorsInfo {
         // active row, and a group that excludes `i` mis-evaluates that filter (skipping the
         // gate's constraints). `compute_filter` relies on this via a release-stripped assert.
         for (gate_idx, &index) in self.selector_indices.iter().enumerate() {
-            let group = self.groups.get(index).ok_or("selector index out of range")?;
+            let group = self
+                .groups
+                .get(index)
+                .ok_or("selector index out of range")?;
             if !group.contains(&gate_idx) {
                 return Err("selector group does not contain its gate");
             }

--- a/core/src/selectors.rs
+++ b/core/src/selectors.rs
@@ -19,6 +19,40 @@ impl SelectorsInfo {
     pub fn num_selectors(&self) -> usize {
         self.groups.len()
     }
+
+    /// Validate selector metadata against the gate set and constant budget.
+    ///
+    /// Intended for deserialization of untrusted data: prevents out-of-bounds selector
+    /// and group indexing and oversized selector-group loops during constraint evaluation.
+    pub fn check_valid(
+        &self,
+        num_gates: usize,
+        num_lookup_selectors: usize,
+        num_constants: usize,
+    ) -> Result<(), &'static str> {
+        if self.selector_indices.len() != num_gates {
+            return Err("selector_indices length does not match the number of gates");
+        }
+        for &index in &self.selector_indices {
+            if index >= self.groups.len() {
+                return Err("selector index out of range");
+            }
+        }
+        for group in &self.groups {
+            if group.start > group.end || group.end > num_gates {
+                return Err("selector group range out of bounds");
+            }
+        }
+        let prefix = self
+            .groups
+            .len()
+            .checked_add(num_lookup_selectors)
+            .ok_or("selector count overflows")?;
+        if prefix > num_constants {
+            return Err("selectors and lookup selectors exceed num_constants");
+        }
+        Ok(())
+    }
 }
 
 /// Enum listing the different selectors for lookup constraints:

--- a/core/src/selectors.rs
+++ b/core/src/selectors.rs
@@ -107,7 +107,7 @@ mod tests {
     fn check_valid_rejects_out_of_range_index() {
         let info = SelectorsInfo {
             selector_indices: vec![0, 5],
-            groups: vec![0..2],
+            groups: vec![0..1, 1..2],
         };
         assert!(info.check_valid(2, 0, 8).is_err());
     }

--- a/plonky2/src/gates/arithmetic_base.rs
+++ b/plonky2/src/gates/arithmetic_base.rs
@@ -23,7 +23,7 @@ use crate::plonk::vars::{
     EvaluationTargets, EvaluationVars, EvaluationVarsBase, EvaluationVarsBaseBatch,
     EvaluationVarsBasePacked,
 };
-use crate::util::serialization::{Buffer, IoResult, Read, Write};
+use crate::util::serialization::{Buffer, IoError, IoResult, Read, Write};
 
 /// A gate which can perform a weighted multiply-add, i.e. `result = c0.x.y + c1.z`. If the config
 /// has enough routed wires, it can support several such operations in one gate.
@@ -69,9 +69,13 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ArithmeticGate
         dst.write_usize(self.num_ops)
     }
 
-    fn deserialize(src: &mut Buffer, _common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
+    fn deserialize(src: &mut Buffer, common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
         let num_ops = src.read_usize()?;
-        Ok(Self { num_ops })
+        let gate = Self::new_from_config(&common_data.config);
+        if num_ops != gate.num_ops {
+            return Err(IoError);
+        }
+        Ok(gate)
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/arithmetic_extension.rs
+++ b/plonky2/src/gates/arithmetic_extension.rs
@@ -19,7 +19,7 @@ use crate::iop::witness::{PartitionWitness, Witness, WitnessWrite};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::{CircuitConfig, CommonCircuitData};
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
-use crate::util::serialization::{Buffer, IoResult, Read, Write};
+use crate::util::serialization::{Buffer, IoError, IoResult, Read, Write};
 
 /// A gate which can perform a weighted multiply-add, i.e. `result = c0.x.y + c1.z`. If the config
 /// has enough routed wires, it can support several such operations in one gate.
@@ -65,9 +65,13 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ArithmeticExte
         dst.write_usize(self.num_ops)
     }
 
-    fn deserialize(src: &mut Buffer, _common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
+    fn deserialize(src: &mut Buffer, common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
         let num_ops = src.read_usize()?;
-        Ok(Self { num_ops })
+        let gate = Self::new_from_config(&common_data.config);
+        if num_ops != gate.num_ops {
+            return Err(IoError);
+        }
+        Ok(gate)
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/coset_interpolation.rs
+++ b/plonky2/src/gates/coset_interpolation.rs
@@ -25,7 +25,7 @@ use crate::iop::witness::{PartitionWitness, Witness, WitnessWrite};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
-use crate::util::serialization::{Buffer, IoResult, Read, Write};
+use crate::util::serialization::{Buffer, IoError, IoResult, Read, Write};
 
 /// One of the instantiations of `InterpolationGate`: allows constraints of variable
 /// degree, up to `1<<subgroup_bits`.
@@ -194,6 +194,17 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for CosetInterpola
         let degree = src.read_usize()?;
         let length = src.read_usize()?;
         let barycentric_weights: Vec<F> = src.read_field_vec(length)?;
+
+        // Structural invariants that hold for any genuinely-built gate; reject otherwise so
+        // evaluation cannot panic on out-of-range slicing or a zero-width interpolation step.
+        if subgroup_bits == 0 || subgroup_bits >= usize::BITS as usize {
+            return Err(IoError);
+        }
+        let num_points = 1usize << subgroup_bits;
+        if degree < 2 || degree > num_points || barycentric_weights.len() != num_points {
+            return Err(IoError);
+        }
+
         Ok(Self {
             subgroup_bits,
             degree,

--- a/plonky2/src/gates/lookup.rs
+++ b/plonky2/src/gates/lookup.rs
@@ -240,10 +240,6 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Loo
         let lut_index = src.read_usize()?;
 
         let lut = common_data.luts.get(lut_index).ok_or(IoError)?.clone();
-        Ok(Self {
-            row,
-            lut,
-            slot_nb,
-        })
+        Ok(Self { row, lut, slot_nb })
     }
 }

--- a/plonky2/src/gates/lookup.rs
+++ b/plonky2/src/gates/lookup.rs
@@ -27,7 +27,7 @@ use crate::plonk::vars::{
     EvaluationTargets, EvaluationVars, EvaluationVarsBase, EvaluationVarsBaseBatch,
     EvaluationVarsBasePacked,
 };
-use crate::util::serialization::{Buffer, IoResult, Read, Write};
+use crate::util::serialization::{Buffer, IoError, IoResult, Read, Write};
 
 pub type Lookup = Vec<(Target, Target)>;
 
@@ -96,9 +96,10 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for LookupGate {
         let mut lut_hash = [0u8; 32];
         src.read_exact(&mut lut_hash)?;
 
+        let lut = common_data.luts.get(lut_index).ok_or(IoError)?.clone();
         Ok(Self {
             num_slots,
-            lut: common_data.luts[lut_index].clone(),
+            lut,
             lut_hash,
         })
     }
@@ -238,9 +239,10 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Loo
         let slot_nb = src.read_usize()?;
         let lut_index = src.read_usize()?;
 
+        let lut = common_data.luts.get(lut_index).ok_or(IoError)?.clone();
         Ok(Self {
             row,
-            lut: common_data.luts[lut_index].clone(),
+            lut,
             slot_nb,
         })
     }

--- a/plonky2/src/gates/lookup_table.rs
+++ b/plonky2/src/gates/lookup_table.rs
@@ -29,7 +29,7 @@ use crate::plonk::vars::{
     EvaluationTargets, EvaluationVars, EvaluationVarsBase, EvaluationVarsBaseBatch,
     EvaluationVarsBasePacked,
 };
-use crate::util::serialization::{Buffer, IoResult, Read, Write};
+use crate::util::serialization::{Buffer, IoError, IoResult, Read, Write};
 
 pub type LookupTable = Arc<Vec<(u16, u16)>>;
 
@@ -111,9 +111,10 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for LookupTableGat
         let mut lut_hash = [0u8; 32];
         src.read_exact(&mut lut_hash)?;
 
+        let lut = common_data.luts.get(lut_index).ok_or(IoError)?.clone();
         Ok(Self {
             num_slots,
-            lut: common_data.luts[lut_index].clone(),
+            lut,
             lut_hash,
             last_lut_row,
         })
@@ -253,9 +254,10 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Loo
         let last_lut_row = src.read_usize()?;
         let lut_index = src.read_usize()?;
 
+        let lut = common_data.luts.get(lut_index).ok_or(IoError)?.clone();
         Ok(Self {
             row,
-            lut: common_data.luts[lut_index].clone(),
+            lut,
             slot_nb,
             num_slots,
             last_lut_row,

--- a/plonky2/src/gates/multiplication_extension.rs
+++ b/plonky2/src/gates/multiplication_extension.rs
@@ -19,7 +19,7 @@ use crate::iop::witness::{PartitionWitness, Witness, WitnessWrite};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::{CircuitConfig, CommonCircuitData};
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
-use crate::util::serialization::{Buffer, IoResult, Read, Write};
+use crate::util::serialization::{Buffer, IoError, IoResult, Read, Write};
 
 /// A gate which can perform a weighted multiplication, i.e. `result = c0.x.y` on [`ExtensionTarget`].
 /// If the config has enough routed wires, it can support several such operations in one gate.
@@ -62,9 +62,13 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for MulExtensionGa
         dst.write_usize(self.num_ops)
     }
 
-    fn deserialize(src: &mut Buffer, _common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
+    fn deserialize(src: &mut Buffer, common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
         let num_ops = src.read_usize()?;
-        Ok(Self { num_ops })
+        let gate = Self::new_from_config(&common_data.config);
+        if num_ops != gate.num_ops {
+            return Err(IoError);
+        }
+        Ok(gate)
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/util/serialization/mod.rs
+++ b/plonky2/src/util/serialization/mod.rs
@@ -857,6 +857,13 @@ pub trait Read {
         )
         .map_err(|_| IoError)?;
 
+        qp_plonky2_core::circuit_config::check_fri_params_consistent(
+            &common_data.config,
+            common_data.public_initial_degree_bits,
+            &common_data.fri_params,
+        )
+        .map_err(|_| IoError)?;
+
         qp_plonky2_core::circuit_config::check_lookup_metadata_valid(
             common_data.num_lookup_polys,
             common_data.num_lookup_selectors,

--- a/plonky2/src/util/serialization/mod.rs
+++ b/plonky2/src/util/serialization/mod.rs
@@ -678,13 +678,15 @@ pub trait Read {
         let proof_of_work_bits = self.read_u32()?;
         let reduction_strategy = self.read_fri_reduction_strategy()?;
 
-        Ok(FriConfig {
+        let config = FriConfig {
             rate_bits,
             cap_height,
             num_query_rounds,
             proof_of_work_bits,
             reduction_strategy,
-        })
+        };
+        config.check_valid().map_err(|_| IoError)?;
+        Ok(config)
     }
 
     fn read_circuit_config(&mut self) -> IoResult<CircuitConfig> {
@@ -719,12 +721,14 @@ pub trait Read {
         let degree_bits = self.read_usize()?;
         let leaf_hiding = self.read_bool()?;
 
-        Ok(FriParams {
+        let params = FriParams {
             config,
             reduction_arity_bits,
             degree_bits,
             leaf_hiding,
-        })
+        };
+        params.check_valid().map_err(|_| IoError)?;
+        Ok(params)
     }
 
     fn read_gate<F: RichField + Extendable<D>, const D: usize>(
@@ -847,9 +851,35 @@ pub trait Read {
             common_data.config.fri_config.rate_bits,
             common_data.public_initial_degree_bits,
             common_data.trace_degree_bits,
+            common_data.num_partial_products,
+            common_data.k_is.len(),
             || common_data.luts.iter().any(|lut| lut.is_empty()),
         )
         .map_err(|_| IoError)?;
+
+        common_data
+            .selectors_info
+            .check_valid(
+                common_data.gates.len(),
+                common_data.num_lookup_selectors,
+                common_data.num_constants,
+            )
+            .map_err(|_| IoError)?;
+
+        let num_selectors = common_data.selectors_info.num_selectors();
+        for gate in &common_data.gates {
+            qp_plonky2_core::circuit_config::check_gate_shape(
+                gate.0.num_wires(),
+                gate.0.num_constants(),
+                gate.0.num_constraints(),
+                &common_data.config,
+                num_selectors,
+                common_data.num_lookup_selectors,
+                common_data.num_constants,
+                common_data.num_gate_constraints,
+            )
+            .map_err(|_| IoError)?;
+        }
 
         Ok(common_data)
     }

--- a/plonky2/src/util/serialization/mod.rs
+++ b/plonky2/src/util/serialization/mod.rs
@@ -32,7 +32,7 @@ use crate::fri::proof::{
 use crate::fri::{FriConfig, FriParams, FriReductionStrategy};
 use crate::gadgets::polynomial::PolynomialCoeffsExtTarget;
 use crate::gates::gate::GateRef;
-use crate::gates::lookup::Lookup;
+use crate::gates::lookup::{Lookup, LookupGate};
 use crate::gates::selectors::SelectorsInfo;
 use crate::hash::hash_types::{HashOutTarget, MerkleCapTarget, RichField};
 use crate::hash::merkle_proofs::{MerkleProof, MerkleProofTarget};
@@ -854,6 +854,15 @@ pub trait Read {
             common_data.num_partial_products,
             common_data.k_is.len(),
             || common_data.luts.iter().any(|lut| lut.is_empty()),
+        )
+        .map_err(|_| IoError)?;
+
+        qp_plonky2_core::circuit_config::check_lookup_metadata_valid(
+            common_data.num_lookup_polys,
+            common_data.num_lookup_selectors,
+            common_data.luts.len(),
+            common_data.quotient_degree_factor,
+            LookupGate::num_slots(&common_data.config),
         )
         .map_err(|_| IoError)?;
 

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use plonky2::field::types::Field;
 use plonky2::field::zero_poly_coset::ZeroPolyOnCoset;
+use plonky2::fri::FriReductionStrategy;
 use plonky2::gadgets::lookup::TIP5_TABLE;
 use plonky2::gates::coset_interpolation::CosetInterpolationGate;
 use plonky2::gates::exponentiation::ExponentiationGate;
@@ -426,22 +427,58 @@ fn genuine_common_data_with_reductions_round_trips() {
 
 #[test]
 fn deserialization_rejects_cleared_reduction_arities() {
-    assert!(tamper_is_rejected(sample_common_data_with_reductions(), |c| {
-        c.fri_params.reduction_arity_bits.clear();
-    }));
+    assert!(tamper_is_rejected(
+        sample_common_data_with_reductions(),
+        |c| {
+            c.fri_params.reduction_arity_bits.clear();
+        }
+    ));
 }
 
 #[test]
 fn deserialization_rejects_altered_reduction_arity() {
-    assert!(tamper_is_rejected(sample_common_data_with_reductions(), |c| {
-        c.fri_params.reduction_arity_bits[0] = 1;
-    }));
+    assert!(tamper_is_rejected(
+        sample_common_data_with_reductions(),
+        |c| {
+            c.fri_params.reduction_arity_bits[0] = 1;
+        }
+    ));
 }
 
 #[test]
 fn deserialization_rejects_flipped_leaf_hiding() {
     assert!(tampered_common_data_is_rejected(|c| {
         c.fri_params.leaf_hiding = !c.fri_params.leaf_hiding;
+    }));
+}
+
+#[test]
+fn deserialization_rejects_zero_constant_arity_strategy() {
+    assert!(tampered_common_data_is_rejected(|c| {
+        let strategy = FriReductionStrategy::ConstantArityBits(0, 0);
+        c.config.fri_config.reduction_strategy = strategy.clone();
+        c.fri_params.config.reduction_strategy = strategy;
+    }));
+}
+
+#[test]
+fn deserialization_rejects_zero_fixed_arity_strategy() {
+    assert!(tampered_common_data_is_rejected(|c| {
+        let strategy = FriReductionStrategy::Fixed(vec![0]);
+        c.config.fri_config.reduction_strategy = strategy.clone();
+        c.fri_params.config.reduction_strategy = strategy;
+        c.fri_params.reduction_arity_bits = vec![0];
+    }));
+}
+
+#[test]
+fn deserialization_rejects_oversized_min_size_query_count() {
+    assert!(tampered_common_data_is_rejected(|c| {
+        let strategy = FriReductionStrategy::MinSize(None);
+        c.config.fri_config.reduction_strategy = strategy.clone();
+        c.config.fri_config.num_query_rounds = usize::MAX;
+        c.fri_params.config.reduction_strategy = strategy;
+        c.fri_params.config.num_query_rounds = usize::MAX;
     }));
 }
 

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -291,6 +291,19 @@ fn sample_lookup_common_data() -> plonky2::plonk::circuit_data::CommonCircuitDat
     builder.build::<C>().common
 }
 
+fn sample_common_data_with_reductions() -> plonky2::plonk::circuit_data::CommonCircuitData<F, D> {
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let mut x = builder.add_virtual_public_input();
+    for _ in 0..5_000 {
+        x = builder.mul(x, x);
+    }
+    builder.register_public_input(x);
+    let common = builder.build::<C>().common;
+    assert!(!common.fri_params.reduction_arity_bits.is_empty());
+    common
+}
+
 fn tamper_is_rejected(
     mut common: plonky2::plonk::circuit_data::CommonCircuitData<F, D>,
     mutate: impl FnOnce(&mut plonky2::plonk::circuit_data::CommonCircuitData<F, D>),
@@ -403,6 +416,32 @@ fn deserialization_rejects_mismatched_fri_rate_bits() {
 fn deserialization_rejects_mismatched_public_initial_degree_bits() {
     assert!(tampered_common_data_is_rejected(|c| {
         c.public_initial_degree_bits += 1;
+    }));
+}
+
+#[test]
+fn genuine_common_data_with_reductions_round_trips() {
+    assert!(common_data_round_trips(sample_common_data_with_reductions()));
+}
+
+#[test]
+fn deserialization_rejects_cleared_reduction_arities() {
+    assert!(tamper_is_rejected(sample_common_data_with_reductions(), |c| {
+        c.fri_params.reduction_arity_bits.clear();
+    }));
+}
+
+#[test]
+fn deserialization_rejects_altered_reduction_arity() {
+    assert!(tamper_is_rejected(sample_common_data_with_reductions(), |c| {
+        c.fri_params.reduction_arity_bits[0] = 1;
+    }));
+}
+
+#[test]
+fn deserialization_rejects_flipped_leaf_hiding() {
+    assert!(tampered_common_data_is_rejected(|c| {
+        c.fri_params.leaf_hiding = !c.fri_params.leaf_hiding;
     }));
 }
 

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -265,3 +265,77 @@ fn zero_poly_on_coset_valid_domain_works() {
     let eval_inverse = z_h.eval_inverse(0);
     assert_eq!(eval * eval_inverse, F::ONE);
 }
+
+fn sample_common_data() -> plonky2::plonk::circuit_data::CommonCircuitData<F, D> {
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let x = builder.add_virtual_public_input();
+    let y = builder.mul(x, x);
+    builder.register_public_input(y);
+    builder.build::<C>().common
+}
+
+fn tampered_common_data_is_rejected(
+    mutate: impl FnOnce(&mut plonky2::plonk::circuit_data::CommonCircuitData<F, D>),
+) -> bool {
+    use plonky2::plonk::circuit_data::CommonCircuitData;
+    use plonky2::util::serialization::DefaultGateSerializer;
+
+    let gate_serializer = DefaultGateSerializer;
+    let mut common = sample_common_data();
+    mutate(&mut common);
+    let bytes = common.to_bytes(&gate_serializer).unwrap();
+    CommonCircuitData::<F, D>::from_bytes(bytes, &gate_serializer).is_err()
+}
+
+#[test]
+fn genuine_common_data_round_trips() {
+    use plonky2::plonk::circuit_data::CommonCircuitData;
+    use plonky2::util::serialization::DefaultGateSerializer;
+
+    let gate_serializer = DefaultGateSerializer;
+    let bytes = sample_common_data().to_bytes(&gate_serializer).unwrap();
+    assert!(CommonCircuitData::<F, D>::from_bytes(bytes, &gate_serializer).is_ok());
+}
+
+#[test]
+fn deserialization_rejects_zero_query_rounds() {
+    assert!(tampered_common_data_is_rejected(|c| {
+        c.config.fri_config.num_query_rounds = 0;
+    }));
+}
+
+#[test]
+fn deserialization_rejects_excessive_reduction_arities() {
+    assert!(tampered_common_data_is_rejected(|c| {
+        c.fri_params.reduction_arity_bits = vec![c.fri_params.degree_bits + 1];
+    }));
+}
+
+#[test]
+fn deserialization_rejects_inconsistent_partial_products() {
+    assert!(tampered_common_data_is_rejected(|c| {
+        c.num_partial_products += 1;
+    }));
+}
+
+#[test]
+fn deserialization_rejects_zero_quotient_degree_factor() {
+    assert!(tampered_common_data_is_rejected(|c| {
+        c.quotient_degree_factor = 0;
+    }));
+}
+
+#[test]
+fn deserialization_rejects_selector_index_length_mismatch() {
+    assert!(tampered_common_data_is_rejected(|c| {
+        c.selectors_info.selector_indices.push(0);
+    }));
+}
+
+#[test]
+fn deserialization_rejects_wrong_k_is_length() {
+    assert!(tampered_common_data_is_rejected(|c| {
+        c.k_is.push(F::ZERO);
+    }));
+}

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -1,6 +1,8 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::Arc;
 
 use plonky2::field::types::Field;
+use plonky2::gadgets::lookup::TIP5_TABLE;
 use plonky2::field::zero_poly_coset::ZeroPolyOnCoset;
 use plonky2::gates::coset_interpolation::CosetInterpolationGate;
 use plonky2::gates::exponentiation::ExponentiationGate;
@@ -275,27 +277,58 @@ fn sample_common_data() -> plonky2::plonk::circuit_data::CommonCircuitData<F, D>
     builder.build::<C>().common
 }
 
-fn tampered_common_data_is_rejected(
+fn sample_lookup_common_data() -> plonky2::plonk::circuit_data::CommonCircuitData<F, D> {
+    use plonky2::gates::lookup_table::LookupTable;
+
+    let table: LookupTable = Arc::new((0u16..256).zip(TIP5_TABLE).collect());
+    let config = CircuitConfig::standard_recursion_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let input = builder.add_virtual_target();
+    let index = builder.add_lookup_table_from_pairs(table);
+    let output = builder.add_lookup_from_index(input, index);
+    builder.register_public_input(input);
+    builder.register_public_input(output);
+    builder.build::<C>().common
+}
+
+fn tamper_is_rejected(
+    mut common: plonky2::plonk::circuit_data::CommonCircuitData<F, D>,
     mutate: impl FnOnce(&mut plonky2::plonk::circuit_data::CommonCircuitData<F, D>),
 ) -> bool {
     use plonky2::plonk::circuit_data::CommonCircuitData;
     use plonky2::util::serialization::DefaultGateSerializer;
 
     let gate_serializer = DefaultGateSerializer;
-    let mut common = sample_common_data();
     mutate(&mut common);
     let bytes = common.to_bytes(&gate_serializer).unwrap();
     CommonCircuitData::<F, D>::from_bytes(bytes, &gate_serializer).is_err()
 }
 
-#[test]
-fn genuine_common_data_round_trips() {
+fn tampered_common_data_is_rejected(
+    mutate: impl FnOnce(&mut plonky2::plonk::circuit_data::CommonCircuitData<F, D>),
+) -> bool {
+    tamper_is_rejected(sample_common_data(), mutate)
+}
+
+fn common_data_round_trips(
+    common: plonky2::plonk::circuit_data::CommonCircuitData<F, D>,
+) -> bool {
     use plonky2::plonk::circuit_data::CommonCircuitData;
     use plonky2::util::serialization::DefaultGateSerializer;
 
     let gate_serializer = DefaultGateSerializer;
-    let bytes = sample_common_data().to_bytes(&gate_serializer).unwrap();
-    assert!(CommonCircuitData::<F, D>::from_bytes(bytes, &gate_serializer).is_ok());
+    let bytes = common.to_bytes(&gate_serializer).unwrap();
+    CommonCircuitData::<F, D>::from_bytes(bytes, &gate_serializer).is_ok()
+}
+
+#[test]
+fn genuine_common_data_round_trips() {
+    assert!(common_data_round_trips(sample_common_data()));
+}
+
+#[test]
+fn genuine_lookup_common_data_round_trips() {
+    assert!(common_data_round_trips(sample_lookup_common_data()));
 }
 
 #[test]
@@ -337,5 +370,57 @@ fn deserialization_rejects_selector_index_length_mismatch() {
 fn deserialization_rejects_wrong_k_is_length() {
     assert!(tampered_common_data_is_rejected(|c| {
         c.k_is.push(F::ZERO);
+    }));
+}
+
+#[test]
+fn deserialization_rejects_routed_wires_exceeding_wires() {
+    assert!(tampered_common_data_is_rejected(|c| {
+        c.config.num_routed_wires = c.config.num_wires + 1;
+    }));
+}
+
+#[test]
+fn deserialization_rejects_phantom_lookup_polys() {
+    assert!(tampered_common_data_is_rejected(|c| {
+        c.num_lookup_polys = 1;
+    }));
+}
+
+#[test]
+fn deserialization_rejects_selector_group_not_containing_gate() {
+    assert!(tamper_is_rejected(sample_lookup_common_data(), |c| {
+        let groups = &c.selectors_info.groups;
+        assert!(
+            groups.len() >= 2,
+            "test requires a circuit with multiple selector groups"
+        );
+        // Reassign gate 0 to a different existing group that does not contain it.
+        let original = c.selectors_info.selector_indices[0];
+        let other = (0..groups.len())
+            .find(|&g| g != original && !groups[g].contains(&0))
+            .expect("expected a non-containing selector group");
+        c.selectors_info.selector_indices[0] = other;
+    }));
+}
+
+#[test]
+fn deserialization_rejects_disabled_lookup_polys() {
+    assert!(tamper_is_rejected(sample_lookup_common_data(), |c| {
+        c.num_lookup_polys = 0;
+    }));
+}
+
+#[test]
+fn deserialization_rejects_degenerate_lookup_polys() {
+    assert!(tamper_is_rejected(sample_lookup_common_data(), |c| {
+        c.num_lookup_polys = 1;
+    }));
+}
+
+#[test]
+fn deserialization_rejects_wrong_lookup_selector_count() {
+    assert!(tamper_is_rejected(sample_lookup_common_data(), |c| {
+        c.num_lookup_selectors += 1;
     }));
 }

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -2,8 +2,8 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 
 use plonky2::field::types::Field;
-use plonky2::gadgets::lookup::TIP5_TABLE;
 use plonky2::field::zero_poly_coset::ZeroPolyOnCoset;
+use plonky2::gadgets::lookup::TIP5_TABLE;
 use plonky2::gates::coset_interpolation::CosetInterpolationGate;
 use plonky2::gates::exponentiation::ExponentiationGate;
 use plonky2::gates::gate::Gate;
@@ -310,9 +310,7 @@ fn tampered_common_data_is_rejected(
     tamper_is_rejected(sample_common_data(), mutate)
 }
 
-fn common_data_round_trips(
-    common: plonky2::plonk::circuit_data::CommonCircuitData<F, D>,
-) -> bool {
+fn common_data_round_trips(common: plonky2::plonk::circuit_data::CommonCircuitData<F, D>) -> bool {
     use plonky2::plonk::circuit_data::CommonCircuitData;
     use plonky2::util::serialization::DefaultGateSerializer;
 

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -426,16 +426,22 @@ fn genuine_common_data_with_reductions_round_trips() {
 
 #[test]
 fn deserialization_rejects_cleared_reduction_arities() {
-    assert!(tamper_is_rejected(sample_common_data_with_reductions(), |c| {
-        c.fri_params.reduction_arity_bits.clear();
-    }));
+    assert!(tamper_is_rejected(
+        sample_common_data_with_reductions(),
+        |c| {
+            c.fri_params.reduction_arity_bits.clear();
+        }
+    ));
 }
 
 #[test]
 fn deserialization_rejects_altered_reduction_arity() {
-    assert!(tamper_is_rejected(sample_common_data_with_reductions(), |c| {
-        c.fri_params.reduction_arity_bits[0] = 1;
-    }));
+    assert!(tamper_is_rejected(
+        sample_common_data_with_reductions(),
+        |c| {
+            c.fri_params.reduction_arity_bits[0] = 1;
+        }
+    ));
 }
 
 #[test]

--- a/plonky2/tests/security_harness.rs
+++ b/plonky2/tests/security_harness.rs
@@ -386,6 +386,27 @@ fn deserialization_rejects_phantom_lookup_polys() {
 }
 
 #[test]
+fn deserialization_rejects_mismatched_fri_query_rounds() {
+    assert!(tampered_common_data_is_rejected(|c| {
+        c.config.fri_config.num_query_rounds -= 1;
+    }));
+}
+
+#[test]
+fn deserialization_rejects_mismatched_fri_rate_bits() {
+    assert!(tampered_common_data_is_rejected(|c| {
+        c.config.fri_config.rate_bits += 1;
+    }));
+}
+
+#[test]
+fn deserialization_rejects_mismatched_public_initial_degree_bits() {
+    assert!(tampered_common_data_is_rejected(|c| {
+        c.public_initial_degree_bits += 1;
+    }));
+}
+
+#[test]
 fn deserialization_rejects_selector_group_not_containing_gate() {
     assert!(tamper_is_rejected(sample_lookup_common_data(), |c| {
         let groups = &c.selectors_info.groups;

--- a/verifier/src/gates/arithmetic_base.rs
+++ b/verifier/src/gates/arithmetic_base.rs
@@ -11,7 +11,7 @@ use crate::plonk::circuit_data::{CircuitConfig, CommonCircuitData};
 use crate::plonk::vars::{
     EvaluationVars, EvaluationVarsBase, EvaluationVarsBaseBatch, EvaluationVarsBasePacked,
 };
-use crate::util::serialization::{Buffer, IoResult, Read, Write};
+use crate::util::serialization::{Buffer, IoError, IoResult, Read, Write};
 
 /// A gate which can perform a weighted multiply-add, i.e. `result = c0.x.y + c1.z`. If the config
 /// has enough routed wires, it can support several such operations in one gate.
@@ -57,9 +57,13 @@ impl<F: RichField + Extendable<D>, const D: usize> VerificationGate<F, D> for Ar
         dst.write_usize(self.num_ops)
     }
 
-    fn deserialize(src: &mut Buffer, _common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
+    fn deserialize(src: &mut Buffer, common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
         let num_ops = src.read_usize()?;
-        Ok(Self { num_ops })
+        let gate = Self::new_from_config(&common_data.config);
+        if num_ops != gate.num_ops {
+            return Err(IoError);
+        }
+        Ok(gate)
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/verifier/src/gates/arithmetic_extension.rs
+++ b/verifier/src/gates/arithmetic_extension.rs
@@ -8,7 +8,7 @@ use crate::gates::util::StridedConstraintConsumer;
 use crate::hash::hash_types::RichField;
 use crate::plonk::circuit_data::{CircuitConfig, CommonCircuitData};
 use crate::plonk::vars::{EvaluationVars, EvaluationVarsBase};
-use crate::util::serialization::{Buffer, IoResult, Read, Write};
+use crate::util::serialization::{Buffer, IoError, IoResult, Read, Write};
 
 /// A gate which can perform a weighted multiply-add, i.e. `result = c0.x.y + c1.z`. If the config
 /// has enough routed wires, it can support several such operations in one gate.
@@ -56,9 +56,13 @@ impl<F: RichField + Extendable<D>, const D: usize> VerificationGate<F, D>
         dst.write_usize(self.num_ops)
     }
 
-    fn deserialize(src: &mut Buffer, _common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
+    fn deserialize(src: &mut Buffer, common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
         let num_ops = src.read_usize()?;
-        Ok(Self { num_ops })
+        let gate = Self::new_from_config(&common_data.config);
+        if num_ops != gate.num_ops {
+            return Err(IoError);
+        }
+        Ok(gate)
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/verifier/src/gates/coset_interpolation.rs
+++ b/verifier/src/gates/coset_interpolation.rs
@@ -12,7 +12,7 @@ use crate::gates::util::StridedConstraintConsumer;
 use crate::hash::hash_types::RichField;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::vars::{EvaluationVars, EvaluationVarsBase};
-use crate::util::serialization::{Buffer, IoResult, Read, Write};
+use crate::util::serialization::{Buffer, IoError, IoResult, Read, Write};
 
 /// One of the instantiations of `InterpolationGate`: allows constraints of variable
 /// degree, up to `1<<subgroup_bits`.
@@ -183,6 +183,17 @@ impl<F: RichField + Extendable<D>, const D: usize> VerificationGate<F, D>
         let degree = src.read_usize()?;
         let length = src.read_usize()?;
         let barycentric_weights: Vec<F> = src.read_field_vec(length)?;
+
+        // Structural invariants that hold for any genuinely-built gate; reject otherwise so
+        // evaluation cannot panic on out-of-range slicing or a zero-width interpolation step.
+        if subgroup_bits == 0 || subgroup_bits >= usize::BITS as usize {
+            return Err(IoError);
+        }
+        let num_points = 1usize << subgroup_bits;
+        if degree < 2 || degree > num_points || barycentric_weights.len() != num_points {
+            return Err(IoError);
+        }
+
         Ok(Self {
             subgroup_bits,
             degree,

--- a/verifier/src/gates/lookup.rs
+++ b/verifier/src/gates/lookup.rs
@@ -15,7 +15,7 @@ use crate::plonk::circuit_data::{CircuitConfig, CommonCircuitData};
 use crate::plonk::vars::{
     EvaluationVars, EvaluationVarsBase, EvaluationVarsBaseBatch, EvaluationVarsBasePacked,
 };
-use crate::util::serialization::{Buffer, IoResult, Read, Write};
+use crate::util::serialization::{Buffer, IoError, IoResult, Read, Write};
 
 /// A gate which stores (input, output) lookup pairs made elsewhere in the trace. It doesn't check any constraints itself.
 #[derive(Debug, Clone)]
@@ -82,9 +82,10 @@ impl<F: RichField + Extendable<D>, const D: usize> VerificationGate<F, D> for Lo
         let mut lut_hash = [0u8; 32];
         src.read_exact(&mut lut_hash)?;
 
+        let lut = common_data.luts.get(lut_index).ok_or(IoError)?.clone();
         Ok(Self {
             num_slots,
-            lut: common_data.luts[lut_index].clone(),
+            lut,
             lut_hash,
         })
     }

--- a/verifier/src/gates/lookup_table.rs
+++ b/verifier/src/gates/lookup_table.rs
@@ -16,7 +16,7 @@ use crate::plonk::circuit_data::{CircuitConfig, CommonCircuitData};
 use crate::plonk::vars::{
     EvaluationVars, EvaluationVarsBase, EvaluationVarsBaseBatch, EvaluationVarsBasePacked,
 };
-use crate::util::serialization::{Buffer, IoResult, Read, Write};
+use crate::util::serialization::{Buffer, IoError, IoResult, Read, Write};
 
 pub type LookupTable = Arc<Vec<(u16, u16)>>;
 
@@ -98,9 +98,10 @@ impl<F: RichField + Extendable<D>, const D: usize> VerificationGate<F, D> for Lo
         let mut lut_hash = [0u8; 32];
         src.read_exact(&mut lut_hash)?;
 
+        let lut = common_data.luts.get(lut_index).ok_or(IoError)?.clone();
         Ok(Self {
             num_slots,
-            lut: common_data.luts[lut_index].clone(),
+            lut,
             lut_hash,
             last_lut_row,
         })

--- a/verifier/src/gates/multiplication_extension.rs
+++ b/verifier/src/gates/multiplication_extension.rs
@@ -8,7 +8,7 @@ use crate::gates::util::StridedConstraintConsumer;
 use crate::hash::hash_types::RichField;
 use crate::plonk::circuit_data::{CircuitConfig, CommonCircuitData};
 use crate::plonk::vars::{EvaluationVars, EvaluationVarsBase};
-use crate::util::serialization::{Buffer, IoResult, Read, Write};
+use crate::util::serialization::{Buffer, IoError, IoResult, Read, Write};
 
 /// A gate which can perform a weighted multiplication, i.e. `result = c0.x.y` on [`crate::iop::ext_target::ExtensionTarget`].
 /// If the config has enough routed wires, it can support several such operations in one gate.
@@ -51,9 +51,13 @@ impl<F: RichField + Extendable<D>, const D: usize> VerificationGate<F, D> for Mu
         dst.write_usize(self.num_ops)
     }
 
-    fn deserialize(src: &mut Buffer, _common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
+    fn deserialize(src: &mut Buffer, common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
         let num_ops = src.read_usize()?;
-        Ok(Self { num_ops })
+        let gate = Self::new_from_config(&common_data.config);
+        if num_ops != gate.num_ops {
+            return Err(IoError);
+        }
+        Ok(gate)
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/verifier/src/util/serialization/mod.rs
+++ b/verifier/src/util/serialization/mod.rs
@@ -25,6 +25,7 @@ use crate::field::extension::{Extendable, FieldExtension};
 use crate::field::polynomial::PolynomialCoeffs;
 use crate::field::types::{Field64, PrimeField64};
 use crate::gates::gate::GateRef;
+use crate::gates::lookup::LookupGate;
 use crate::gates::selectors::SelectorsInfo;
 use crate::hash::hash_types::RichField;
 use crate::plonk::circuit_data::{
@@ -566,6 +567,15 @@ pub trait Read {
             common_data.num_partial_products,
             common_data.k_is.len(),
             || common_data.luts.iter().any(|lut| lut.is_empty()),
+        )
+        .map_err(|_| IoError)?;
+
+        qp_plonky2_core::circuit_config::check_lookup_metadata_valid(
+            common_data.num_lookup_polys,
+            common_data.num_lookup_selectors,
+            common_data.luts.len(),
+            common_data.quotient_degree_factor,
+            LookupGate::num_slots(&common_data.config),
         )
         .map_err(|_| IoError)?;
 

--- a/verifier/src/util/serialization/mod.rs
+++ b/verifier/src/util/serialization/mod.rs
@@ -424,13 +424,15 @@ pub trait Read {
         let proof_of_work_bits = self.read_u32()?;
         let reduction_strategy = self.read_fri_reduction_strategy()?;
 
-        Ok(FriConfig {
+        let config = FriConfig {
             rate_bits,
             cap_height,
             num_query_rounds,
             proof_of_work_bits,
             reduction_strategy,
-        })
+        };
+        config.check_valid().map_err(|_| IoError)?;
+        Ok(config)
     }
 
     fn read_circuit_config(&mut self) -> IoResult<CircuitConfig> {
@@ -465,12 +467,14 @@ pub trait Read {
         let degree_bits = self.read_usize()?;
         let leaf_hiding = self.read_bool()?;
 
-        Ok(FriParams {
+        let params = FriParams {
             config,
             reduction_arity_bits,
             degree_bits,
             leaf_hiding,
-        })
+        };
+        params.check_valid().map_err(|_| IoError)?;
+        Ok(params)
     }
 
     fn read_gate<F: RichField + Extendable<D>, const D: usize>(
@@ -559,9 +563,35 @@ pub trait Read {
             common_data.config.fri_config.rate_bits,
             common_data.public_initial_degree_bits,
             common_data.trace_degree_bits,
+            common_data.num_partial_products,
+            common_data.k_is.len(),
             || common_data.luts.iter().any(|lut| lut.is_empty()),
         )
         .map_err(|_| IoError)?;
+
+        common_data
+            .selectors_info
+            .check_valid(
+                common_data.gates.len(),
+                common_data.num_lookup_selectors,
+                common_data.num_constants,
+            )
+            .map_err(|_| IoError)?;
+
+        let num_selectors = common_data.selectors_info.num_selectors();
+        for gate in &common_data.gates {
+            qp_plonky2_core::circuit_config::check_gate_shape(
+                gate.0.num_wires(),
+                gate.0.num_constants(),
+                gate.0.num_constraints(),
+                &common_data.config,
+                num_selectors,
+                common_data.num_lookup_selectors,
+                common_data.num_constants,
+                common_data.num_gate_constraints,
+            )
+            .map_err(|_| IoError)?;
+        }
 
         Ok(common_data)
     }

--- a/verifier/src/util/serialization/mod.rs
+++ b/verifier/src/util/serialization/mod.rs
@@ -570,6 +570,13 @@ pub trait Read {
         )
         .map_err(|_| IoError)?;
 
+        qp_plonky2_core::circuit_config::check_fri_params_consistent(
+            &common_data.config,
+            common_data.public_initial_degree_bits,
+            &common_data.fri_params,
+        )
+        .map_err(|_| IoError)?;
+
         qp_plonky2_core::circuit_config::check_lookup_metadata_valid(
             common_data.num_lookup_polys,
             common_data.num_lookup_selectors,


### PR DESCRIPTION
Addresses the serialized-data cluster in #71 (and the #60 hardening): route verifier/common/circuit-data deserialization through validators so forged metadata is rejected with an `Err` instead of panicking or under-constraining during verification.

Inert on-chain today — the VK is a compile-time `include_bytes!` constant — but this is the hardening required before any untrusted-VK / general-purpose verify API.

## Changes
Shared validators in `core` (DRY: used by both `plonky2` and `verifier`):
- `FriConfig::check_valid` — reject `num_query_rounds == 0`
- `FriParams::check_valid` — reject reduction-arity sum > `degree_bits`
- `SelectorsInfo::check_valid` — selector indices / group ranges vs gate set & constants
- `check_common_data_valid` — `quotient_degree_factor >= 1`, recomputed `num_partial_products`, `k_is.len() == num_routed_wires`
- `check_gate_shape` — each gate's wires/constants/constraints fit `CommonCircuitData`

Wired into `read_fri_config` / `read_fri_params` / `read_common_circuit_data` in both crates. Lookup gates + generators use checked LUT indexing; config-derived gates (`Arithmetic`, `ArithmeticExtension`, `MulExtension`) deserialize via `new_from_config`; `CosetInterpolationGate` validates `subgroup_bits`/`degree`/weights length.

Findings covered: #79683, #79687, #79688, #79689, #78811, #79616, #79636, #79695, #79698, #79704, #79720, #79721.

## Scope
Verifier/common/circuit data only, per the ticket. Prover-side generator witness indices (`row`/`num_slots`) are a separate data category and out of scope; the LUT-index panic vector of #79720 is fixed in the generators too.

## Test plan
- [x] Genuine data still round-trips — cross-crate gate + full recursive-proof suites, recursion (incl. LUTs), verifier crate tests
- [x] Malformed metadata rejected end-to-end — new `security_harness` tamper tests (query rounds, arities, partial products, quotient factor, selectors, `k_is`) + `core` unit tests
- [x] `core` + `verifier` build with `--no-default-features` (no_std / wasm runtime path)