### PR TITLE
ci: Automate version bump to v1.5.1

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qp-plonky2-core"
 description = "Core traits and types shared between plonky2 prover and verifier"
-version = "1.4.1"
+version = "1.5.1"
 authors = [
   "Daniel Lubarov <daniel@lubarov.com>",
   "William Borgeaud <williamborgeaud@gmail.com>",

--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qp-plonky2-field"
 description = "Finite field arithmetic"
-version = "1.4.1"
+version = "1.5.1"
 authors = [
   "Daniel Lubarov <daniel@lubarov.com>",
   "William Borgeaud <williamborgeaud@gmail.com>",

--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qp-plonky2"
 description = "Recursive SNARKs based on PLONK and FRI"
-version = "1.4.1"
+version = "1.5.1"
 authors = [
   "Daniel Lubarov <daniel@lubarov.com>",
   "William Borgeaud <williamborgeaud@gmail.com>",

--- a/starky/Cargo.toml
+++ b/starky/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "starky"
 description = "Implementation of STARKs"
-version = "1.4.1"
+version = "1.5.1"
 authors = [
   "Daniel Lubarov <daniel@lubarov.com>",
   "William Borgeaud <williamborgeaud@gmail.com>",

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qp-plonky2-verifier"
 description = "Plonky2 verification library - minimal, no-std compatible, no randomness required"
-version = "1.4.1"
+version = "1.5.1"
 authors = [
   "Daniel Lubarov <daniel@lubarov.com>",
   "William Borgeaud <williamborgeaud@gmail.com>",


### PR DESCRIPTION
Automated version bump for release v1.5.1.

https://github.com/Quantus-Network/qp-plonky2/actions/runs/26995678473

Triggered by workflow run: custom

Type: 