### PR TITLE
Bump poseidon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "qp-poseidon-core"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78172860cd960773c72e97fba07ead9e5a1c13086c5746283744933e2e4a577b"
+checksum = "d3fd767cf8aaecf9369fab79255ff9e0ea439cdfef941976edbfb8ba70435b63"
 
 [[package]]
 name = "quote"

--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -47,7 +47,7 @@ critical-section = { version = "=1.2.0", default-features = false, features = [
 hashbrown = { workspace = true }
 itertools = { workspace = true }
 keccak-hash = { version = "=0.8.0", default-features = false }
-qp-poseidon-core = { version = "=2.1.0", default-features = false }
+qp-poseidon-core = { version = "=3.0.0", default-features = false }
 rand = { workspace = true }
 log = { workspace = true }
 num = { workspace = true }

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -47,7 +47,7 @@ static_assertions = { workspace = true }
 unroll = { workspace = true }
 
 # Poseidon2 - self-contained implementation
-qp-poseidon-core = { version = "=2.1.0", default-features = false }
+qp-poseidon-core = { version = "=3.0.0", default-features = false }
 
 # Local dependencies - note: no "rand" feature = verification-only, no randomness needed
 plonky2-field = { package = "qp-plonky2-field", version = "=1.5.1", path = "../field", default-features = false }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> A major-version bump of the Poseidon hash primitive affects prover and verifier builds; any constant or API change in 3.0.0 could break proof compatibility or verification unless the upstream crate is wire-compatible.
> 
> **Overview**
> Upgrades the shared **Poseidon2** crate `qp-poseidon-core` from **2.1.0** to **3.0.0** in both `qp-plonky2` and `qp-plonky2-verifier`, and refreshes `Cargo.lock` with the new registry checksum.
> 
> There are **no application source changes** in this PR—only dependency pins and the lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b330ae891c52f47d0ff8b404f1ce7e0c7ae5d61. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->