### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/create-release-proposal.yml
+++ b/.github/workflows/create-release-proposal.yml
@@ -155,11 +155,17 @@ jobs:
             done
           done
 
+          # constraint-exporter is not published but is in the workspace and pins release crates
+          for pkg in "${release_pkgs[@]}"; do
+            sed -i -E "s/(package = \"$pkg\", version = \"=?)[0-9a-zA-Z.-]+(\")/\1$new_cargo_version\2/g" constraint-exporter/Cargo.toml
+            sed -i -E "s/(^$pkg = \{ version = \"=?)[0-9a-zA-Z.-]+(\")/\1$new_cargo_version\2/g" constraint-exporter/Cargo.toml
+          done
+
           # Commit changes (no lockfile in libs)
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
           
-          git add field/Cargo.toml core/Cargo.toml verifier/Cargo.toml plonky2/Cargo.toml starky/Cargo.toml
+          git add field/Cargo.toml core/Cargo.toml verifier/Cargo.toml plonky2/Cargo.toml starky/Cargo.toml constraint-exporter/Cargo.toml
           git commit -m "ci: Automate version bump to $NEW_VERSION"
           git push origin "$branch_name"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "qp-plonky2"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "qp-plonky2-core"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "qp-plonky2-field"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "itertools 0.11.0",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "qp-plonky2-verifier"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1013,7 +1013,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "starky"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "ahash",
  "anyhow",

--- a/constraint-exporter/Cargo.toml
+++ b/constraint-exporter/Cargo.toml
@@ -22,7 +22,7 @@ publish = false
 plonky2 = { package = "qp-plonky2", path = "../plonky2", features = [
   "formal-export",
 ] }
-qp-plonky2-core = { version = "=1.5.1", path = "../core" }
+qp-plonky2-core = { version = "=1.5.2", path = "../core" }
 num = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qp-plonky2-core"
 description = "Core traits and types shared between plonky2 prover and verifier"
-version = "1.5.1"
+version = "1.5.2"
 authors = [
   "Daniel Lubarov <daniel@lubarov.com>",
   "William Borgeaud <williamborgeaud@gmail.com>",
@@ -33,7 +33,7 @@ static_assertions = { workspace = true }
 unroll = { workspace = true }
 
 # Local dependencies
-plonky2-field = { package = "qp-plonky2-field", version = "=1.5.1", path = "../field", default-features = false }
+plonky2-field = { package = "qp-plonky2-field", version = "=1.5.2", path = "../field", default-features = false }
 plonky2_util = { version = "=1.0.0", path = "../util", default-features = false }
 
 # Optional dependencies
@@ -41,7 +41,7 @@ rand = { version = "=0.10.1", default-features = false, optional = true }
 
 [dev-dependencies]
 rand = { version = "=0.10.1", features = ["std_rng"] }
-plonky2-field = { package = "qp-plonky2-field", version = "=1.5.1", path = "../field", features = [
+plonky2-field = { package = "qp-plonky2-field", version = "=1.5.2", path = "../field", features = [
   "rand",
 ] }
 

--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qp-plonky2-field"
 description = "Finite field arithmetic"
-version = "1.5.1"
+version = "1.5.2"
 authors = [
   "Daniel Lubarov <daniel@lubarov.com>",
   "William Borgeaud <williamborgeaud@gmail.com>",

--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qp-plonky2"
 description = "Recursive SNARKs based on PLONK and FRI"
-version = "1.5.1"
+version = "1.5.2"
 authors = [
   "Daniel Lubarov <daniel@lubarov.com>",
   "William Borgeaud <williamborgeaud@gmail.com>",
@@ -57,11 +57,11 @@ unroll = { workspace = true }
 web-time = { version = "=1.1.0", optional = true }
 
 # Local dependencies
-plonky2-field = { package = "qp-plonky2-field", version = "=1.5.1", path = "../field", default-features = false }
-plonky2-verifier = { package = "qp-plonky2-verifier", version = "=1.5.1", path = "../verifier", default-features = false }
+plonky2-field = { package = "qp-plonky2-field", version = "=1.5.2", path = "../field", default-features = false }
+plonky2-verifier = { package = "qp-plonky2-verifier", version = "=1.5.2", path = "../verifier", default-features = false }
 plonky2_maybe_rayon = { version = "=1.0.0", path = "../maybe_rayon", default-features = false }
 plonky2_util = { version = "=1.0.0", path = "../util", default-features = false }
-qp-plonky2-core = { version = "=1.5.1", path = "../core", default-features = false }
+qp-plonky2-core = { version = "=1.5.2", path = "../core", default-features = false }
 
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]

--- a/starky/Cargo.toml
+++ b/starky/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "starky"
 description = "Implementation of STARKs"
-version = "1.5.1"
+version = "1.5.2"
 authors = [
   "Daniel Lubarov <daniel@lubarov.com>",
   "William Borgeaud <williamborgeaud@gmail.com>",
@@ -31,7 +31,7 @@ serde = { workspace = true, features = ["rc"] }
 num-bigint = { version = "=0.4.6", default-features = false }
 
 # Local dependencies
-qp-plonky2 = { version = "=1.5.1", path = "../plonky2", default-features = false }
+qp-plonky2 = { version = "=1.5.2", path = "../plonky2", default-features = false }
 plonky2_maybe_rayon = { version = "=1.0.0", path = "../maybe_rayon", default-features = false }
 plonky2_util = { version = "=1.0.0", path = "../util", default-features = false }
 

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qp-plonky2-verifier"
 description = "Plonky2 verification library - minimal, no-std compatible, no randomness required"
-version = "1.5.1"
+version = "1.5.2"
 authors = [
   "Daniel Lubarov <daniel@lubarov.com>",
   "William Borgeaud <williamborgeaud@gmail.com>",
@@ -50,14 +50,14 @@ unroll = { workspace = true }
 qp-poseidon-core = { version = "=2.1.0", default-features = false }
 
 # Local dependencies - note: no "rand" feature = verification-only, no randomness needed
-plonky2-field = { package = "qp-plonky2-field", version = "=1.5.1", path = "../field", default-features = false }
+plonky2-field = { package = "qp-plonky2-field", version = "=1.5.2", path = "../field", default-features = false }
 plonky2_util = { version = "=1.0.0", path = "../util", default-features = false }
-qp-plonky2-core = { version = "=1.5.1", path = "../core", default-features = false }
+qp-plonky2-core = { version = "=1.5.2", path = "../core", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "=0.5.1", default-features = false }
 rand = { version = "=0.10.1", features = ["std_rng"] }
-plonky2-field = { package = "qp-plonky2-field", version = "=1.5.1", path = "../field", features = [
+plonky2-field = { package = "qp-plonky2-field", version = "=1.5.2", path = "../field", features = [
   "rand",
 ] }
 # path-only (no version): qp-plonky2 depends on this crate, so a versioned


### PR DESCRIPTION
include constraint-exporter 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and CI workflow changes only; no runtime or cryptographic logic is modified.
> 
> **Overview**
> **Fixes automated release proposals** so `constraint-exporter` stays in sync when workspace crates are bumped. The `create-release-proposal` workflow now runs the same `sed` updates on `constraint-exporter/Cargo.toml` for pinned release packages and stages that file in the version-bump commit.
> 
> This PR also applies the **1.5.1 → 1.5.2** bump across the published crates (`field`, `core`, `verifier`, `plonky2`, `starky`), their `=`-pinned inter-crate versions, `constraint-exporter`’s `qp-plonky2-core` pin, and **`Cargo.lock`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a99b43f62b8db932b7dc6d37dd3acc85b9b9f714. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->