### PR TITLE
ci: Automate version bump to v1.5.3

### DIFF
--- a/constraint-exporter/Cargo.toml
+++ b/constraint-exporter/Cargo.toml
@@ -22,7 +22,7 @@ publish = false
 plonky2 = { package = "qp-plonky2", path = "../plonky2", features = [
   "formal-export",
 ] }
-qp-plonky2-core = { version = "=1.5.2", path = "../core" }
+qp-plonky2-core = { version = "=1.5.3", path = "../core" }
 num = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qp-plonky2-core"
 description = "Core traits and types shared between plonky2 prover and verifier"
-version = "1.5.2"
+version = "1.5.3"
 authors = [
   "Daniel Lubarov <daniel@lubarov.com>",
   "William Borgeaud <williamborgeaud@gmail.com>",
@@ -33,7 +33,7 @@ static_assertions = { workspace = true }
 unroll = { workspace = true }
 
 # Local dependencies
-plonky2-field = { package = "qp-plonky2-field", version = "=1.5.2", path = "../field", default-features = false }
+plonky2-field = { package = "qp-plonky2-field", version = "=1.5.3", path = "../field", default-features = false }
 plonky2_util = { version = "=1.0.0", path = "../util", default-features = false }
 
 # Optional dependencies
@@ -41,7 +41,7 @@ rand = { version = "=0.10.1", default-features = false, optional = true }
 
 [dev-dependencies]
 rand = { version = "=0.10.1", features = ["std_rng"] }
-plonky2-field = { package = "qp-plonky2-field", version = "=1.5.2", path = "../field", features = [
+plonky2-field = { package = "qp-plonky2-field", version = "=1.5.3", path = "../field", features = [
   "rand",
 ] }
 

--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qp-plonky2-field"
 description = "Finite field arithmetic"
-version = "1.5.2"
+version = "1.5.3"
 authors = [
   "Daniel Lubarov <daniel@lubarov.com>",
   "William Borgeaud <williamborgeaud@gmail.com>",

--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qp-plonky2"
 description = "Recursive SNARKs based on PLONK and FRI"
-version = "1.5.2"
+version = "1.5.3"
 authors = [
   "Daniel Lubarov <daniel@lubarov.com>",
   "William Borgeaud <williamborgeaud@gmail.com>",
@@ -57,11 +57,11 @@ unroll = { workspace = true }
 web-time = { version = "=1.1.0", optional = true }
 
 # Local dependencies
-plonky2-field = { package = "qp-plonky2-field", version = "=1.5.2", path = "../field", default-features = false }
-plonky2-verifier = { package = "qp-plonky2-verifier", version = "=1.5.2", path = "../verifier", default-features = false }
+plonky2-field = { package = "qp-plonky2-field", version = "=1.5.3", path = "../field", default-features = false }
+plonky2-verifier = { package = "qp-plonky2-verifier", version = "=1.5.3", path = "../verifier", default-features = false }
 plonky2_maybe_rayon = { version = "=1.0.0", path = "../maybe_rayon", default-features = false }
 plonky2_util = { version = "=1.0.0", path = "../util", default-features = false }
-qp-plonky2-core = { version = "=1.5.2", path = "../core", default-features = false }
+qp-plonky2-core = { version = "=1.5.3", path = "../core", default-features = false }
 
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]

--- a/starky/Cargo.toml
+++ b/starky/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "starky"
 description = "Implementation of STARKs"
-version = "1.5.2"
+version = "1.5.3"
 authors = [
   "Daniel Lubarov <daniel@lubarov.com>",
   "William Borgeaud <williamborgeaud@gmail.com>",
@@ -31,7 +31,7 @@ serde = { workspace = true, features = ["rc"] }
 num-bigint = { version = "=0.4.6", default-features = false }
 
 # Local dependencies
-qp-plonky2 = { version = "=1.5.2", path = "../plonky2", default-features = false }
+qp-plonky2 = { version = "=1.5.3", path = "../plonky2", default-features = false }
 plonky2_maybe_rayon = { version = "=1.0.0", path = "../maybe_rayon", default-features = false }
 plonky2_util = { version = "=1.0.0", path = "../util", default-features = false }
 

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qp-plonky2-verifier"
 description = "Plonky2 verification library - minimal, no-std compatible, no randomness required"
-version = "1.5.2"
+version = "1.5.3"
 authors = [
   "Daniel Lubarov <daniel@lubarov.com>",
   "William Borgeaud <williamborgeaud@gmail.com>",
@@ -50,14 +50,14 @@ unroll = { workspace = true }
 qp-poseidon-core = { version = "=3.0.0", default-features = false }
 
 # Local dependencies - note: no "rand" feature = verification-only, no randomness needed
-plonky2-field = { package = "qp-plonky2-field", version = "=1.5.2", path = "../field", default-features = false }
+plonky2-field = { package = "qp-plonky2-field", version = "=1.5.3", path = "../field", default-features = false }
 plonky2_util = { version = "=1.0.0", path = "../util", default-features = false }
-qp-plonky2-core = { version = "=1.5.2", path = "../core", default-features = false }
+qp-plonky2-core = { version = "=1.5.3", path = "../core", default-features = false }
 
 [dev-dependencies]
 criterion = { version = "=0.5.1", default-features = false }
 rand = { version = "=0.10.1", features = ["std_rng"] }
-plonky2-field = { package = "qp-plonky2-field", version = "=1.5.2", path = "../field", features = [
+plonky2-field = { package = "qp-plonky2-field", version = "=1.5.3", path = "../field", features = [
   "rand",
 ] }
 # path-only (no version): qp-plonky2 depends on this crate, so a versioned


### PR DESCRIPTION
Automated version bump for release v1.5.3.

https://github.com/Quantus-Network/qp-plonky2/actions/runs/29385687307

Triggered by workflow run: patch

Type: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only version alignment with no logic changes; main operational risk is consumers needing to pick up the new crate versions on publish.
> 
> **Overview**
> Automated **patch release** that bumps the published `qp-plonky2` stack from **1.5.2 → 1.5.3** across crate manifests only—no Rust source changes in this diff.
> 
> **Package versions** updated on `qp-plonky2-field`, `qp-plonky2-core`, `qp-plonky2-verifier`, `qp-plonky2`, and `starky`. **Path dependency pins** (`version = "=1.5.3"`) are aligned in `plonky2`, `core`, `verifier`, `starky`, and `constraint-exporter` (which still declares its own package version **1.5.1** but now depends on `qp-plonky2-core` **1.5.3**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ab382b4fd4a5558a1e609026c6eb01b0c833b01. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->